### PR TITLE
Added tests for math function migrations

### DIFF
--- a/features/config/TEMPLATE_math_habs.xml
+++ b/features/config/TEMPLATE_math_habs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test driverID="test_feature" name="TEMPLATE">
+    <description>test</description>
+    <files>
+        <file path="feature_case/math/${testName}.cu" />
+    </files>
+    <rules>
+        <optlevelRule excludeOptlevelNameString="cpu" />
+        <platformRule OSFamily="Linux" kit="CUDA10.2" kitRange="OLDER" runOnThisPlatform="false"/>
+        <platformRule OSFamily="Windows" kit="CUDA10.2" kitRange="OLDER" runOnThisPlatform="false"/>
+    </rules>
+</test>

--- a/features/feature_case/math/math-exec.cu
+++ b/features/feature_case/math/math-exec.cu
@@ -1,0 +1,55 @@
+// ====------ math-exec.cu---------- *- CUDA -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <cassert>
+#include <iostream>
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+
+__global__ void testMathFunctions(char *const TestResults) {
+  {
+    __half2 h2 = __halves2half2(1.1, 1.1);
+    h2 = __hadd2(h2, h2);
+    TestResults[0] =
+        (__low2half(h2) == half(2.2) && __high2half(h2) == half(2.2));
+  }
+
+  {
+    __half h = half(0.5);
+    h = hrcp(h);
+    TestResults[1] = (h == half(2));
+  }
+
+  {
+    long l = -5;
+    l = labs(l);
+    TestResults[2] = (l == long(5l));
+  }
+
+  {
+    long long ll = -10;
+    ll = llabs(ll);
+    TestResults[3] = (ll == 10ll);
+  }
+}
+
+int main() {
+  constexpr int NumberOfTests = 4;
+  char *TestResults;
+  cudaMallocManaged(&TestResults, NumberOfTests * sizeof(*TestResults));
+  testMathFunctions<<<1, 1>>>(TestResults);
+  cudaDeviceSynchronize();
+  for (int i = 0; i < NumberOfTests; i++) {
+    if (TestResults[i] == 0) {
+      std::cout << "Test " << i << " failed" << std::endl;
+    }
+    assert(TestResults[i] != 0);
+  }
+}

--- a/features/feature_case/math/math-habs.cu
+++ b/features/feature_case/math/math-habs.cu
@@ -1,0 +1,43 @@
+// ====------ math-habs.cu---------- *- CUDA -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <cassert>
+#include <iostream>
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+
+__global__ void testMathFunctions(char *const TestResults) {
+  {
+    __half h = -3.14;
+    h = __habs(h);
+    TestResults[0] = (h == half(3.14));
+  }
+
+  {
+    __half2 h2 = __halves2half2(-1.1, -1.1);
+    h2 = __habs2(h2);
+    TestResults[1] =
+        (__low2half(h2) == half(1.1) && __high2half(h2) == half(1.1));
+  }
+}
+
+int main() {
+  constexpr int NumberOfTests = 2;
+  char *TestResults;
+  cudaMallocManaged(&TestResults, NumberOfTests * sizeof(*TestResults));
+  testMathFunctions<<<1, 1>>>(TestResults);
+  cudaDeviceSynchronize();
+  for (int i = 0; i < NumberOfTests; i++) {
+    if (TestResults[i] == 0) {
+      std::cout << "Test " << i << " failed" << std::endl;
+    }
+    assert(TestResults[i] != 0);
+  }
+}

--- a/features/features.xml
+++ b/features/features.xml
@@ -45,6 +45,8 @@
     <test testName="cublas-usm" configFile="config/TEMPLATE_cuBlas.xml" />
     <test testName="math-direct" configFile="config/TEMPLATE_math.xml" />
     <test testName="math-emu" configFile="config/TEMPLATE_math.xml" />
+    <test testName="math-exec" configFile="config/TEMPLATE_math.xml" />
+    <test testName="math-habs" configFile="config/TEMPLATE_math_habs.xml" />
     <test testName="math-helper" configFile="config/TEMPLATE_math.xml" />
     <test testName="cusparse" configFile="config/TEMPLATE_cusparse.xml" />
     <test testName="cusparse-type10.1" configFile="config/TEMPLATE_cuParse.xml" />

--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -20,7 +20,7 @@ exec_tests = ['thrust-vector-2', 'thrust-binary-search', 'thrust-count', 'thrust
              'thrust-qmc', 'thrust-transform-if', 'thrust-policy', 'thrust-list', 'module-kernel',
              'kernel-launch', 'thrust-gather', 'thrust-scatter', 'thrust-unique_by_key_copy', 'thrust-for-hypre',
              'thrust-rawptr-noneusm', 'driverStreamAndEvent', 'grid_sync', 'deviceProp', 'cub_block_p2',
-             'cub_device', 'activemask', 'complex', 'user_defined_rules']
+             'cub_device', 'activemask', 'complex', 'user_defined_rules', 'math-exec', 'math-habs']
 
 def setup_test():
     return True


### PR DESCRIPTION
This PR adds tests for the following math API functions:

- `__hadd2`
- `__habs`
- `__habs2`
- `labs`
- `llabs`