### PR TITLE
Fix math API test issues

### DIFF
--- a/features/config/TEMPLATE_math_exec.xml
+++ b/features/config/TEMPLATE_math_exec.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test driverID="test_feature" name="TEMPLATE">
+    <description>test</description>
+    <files>
+        <file path="feature_case/math/${testName}.cu" />
+    </files>
+    <rules>
+        <platformRule OSFamily="Linux" kit="CUDA11.2" kitRange="OLDER" runOnThisPlatform="false"/>
+        <platformRule OSFamily="Windows" kit="CUDA11.2" kitRange="OLDER" runOnThisPlatform="false"/>
+    </rules>
+</test>

--- a/features/feature_case/math/math-exec.cu
+++ b/features/feature_case/math/math-exec.cu
@@ -18,13 +18,13 @@ __global__ void testMathFunctions(char *const TestResults) {
     __half2 h2 = __halves2half2(1.1, 1.1);
     h2 = __hadd2(h2, h2);
     TestResults[0] =
-        (__low2half(h2) == half(2.2) && __high2half(h2) == half(2.2));
+        (__low2half(h2) == __half(2.2) && __high2half(h2) == __half(2.2));
   }
 
   {
-    __half h = half(0.5);
+    __half h = __half(0.5);
     h = hrcp(h);
-    TestResults[1] = (h == half(2));
+    TestResults[1] = (h == __half(2));
   }
 
   {
@@ -49,7 +49,8 @@ int main() {
   for (int i = 0; i < NumberOfTests; i++) {
     if (TestResults[i] == 0) {
       std::cout << "Test " << i << " failed" << std::endl;
+      return 1;
     }
-    assert(TestResults[i] != 0);
   }
+  return 0;
 }

--- a/features/feature_case/math/math-habs.cu
+++ b/features/feature_case/math/math-habs.cu
@@ -37,7 +37,8 @@ int main() {
   for (int i = 0; i < NumberOfTests; i++) {
     if (TestResults[i] == 0) {
       std::cout << "Test " << i << " failed" << std::endl;
+      return 1;
     }
-    assert(TestResults[i] != 0);
   }
+  return 0;
 }

--- a/features/features.xml
+++ b/features/features.xml
@@ -45,7 +45,7 @@
     <test testName="cublas-usm" configFile="config/TEMPLATE_cuBlas.xml" />
     <test testName="math-direct" configFile="config/TEMPLATE_math.xml" />
     <test testName="math-emu" configFile="config/TEMPLATE_math.xml" />
-    <test testName="math-exec" configFile="config/TEMPLATE_math.xml" />
+    <test testName="math-exec" configFile="config/TEMPLATE_math_exec.xml" />
     <test testName="math-funnelshift" configFile="config/TEMPLATE_math_funnelshift.xml" />
     <test testName="math-habs" configFile="config/TEMPLATE_math_habs.xml" />
     <test testName="math-helper" configFile="config/TEMPLATE_math.xml" />


### PR DESCRIPTION
This PR includes the following changes:

- Replaces assertions with return statements for `math-exec` and `math-habs` tests.
- Specifies minimum CUDA version for `math-exec` tests.