### PR TITLE
[SYCLomatic] Ensure drcp* are migrated with 64-bit accuracy

### DIFF
--- a/features/feature_case/math/math-drcp.cu
+++ b/features/feature_case/math/math-drcp.cu
@@ -1,0 +1,65 @@
+#include <iostream>
+#include <math.h>
+
+__global__
+void recip( double *x, double *y)
+{
+    int a = *x;
+
+    y[0] = __drcp_rd(*x);
+    y[1] = __drcp_rn(*x);
+    y[2] = __drcp_ru(*x);
+    y[3] = __drcp_rz(*x);
+}
+
+static bool moreThanOneLSBDiff(double a, double b) {
+  union dbl_and_ll {
+    double     dbl;
+    long long   ll;
+  };
+
+  dbl_and_ll cmp_a, cmp_b;
+
+  cmp_a.dbl = a;
+  cmp_b.dbl = b;
+
+  if (abs(cmp_a.ll-cmp_b.ll)>1) {
+    return true;
+  }
+  return false;
+}
+
+int main(void)
+{
+  double *x, *y;
+
+  cudaMallocManaged(&x, sizeof(double));
+  cudaMallocManaged(&y, 4*sizeof(double));
+
+  *x = 1.234567891234;
+ 
+  for (int i=0; i<10; i++)  {
+    std::cout << "Iteration " << i << " " << 1.0/x[0] << "\n";
+    recip<<<1, 1>>>(x, y);
+
+   cudaDeviceSynchronize();
+
+   // ensure that migrated drcp* intrinsics produce results that are at
+   // most one-bit off (due to rounding) of standard double-precision division.  
+   // This ensures that migrated code still has double-precision accuracy.
+   if (moreThanOneLSBDiff(y[0],(1.0/x[0])) ||
+       moreThanOneLSBDiff(y[1],(1.0/x[0])) ||
+       moreThanOneLSBDiff(y[2],(1.0/x[0])) ||
+       moreThanOneLSBDiff(y[3],(1.0/x[0]))) {
+      std::cout << "Failed\n" ;
+      return 1;
+    } 
+    (*x)+=123.1241241;
+  }
+
+  cudaFree(x);
+  cudaFree(y);
+  
+  std::cout << "Passed\n";
+  return 0;
+}

--- a/features/features.xml
+++ b/features/features.xml
@@ -50,6 +50,7 @@
     <test testName="cublas-usm" configFile="config/TEMPLATE_cuBlas.xml" />
     <test testName="math-bfloat16" configFile="config/TEMPLATE_math_bfloat16.xml" />
     <test testName="math-direct" configFile="config/TEMPLATE_math.xml" />
+    <test testName="math-drcp" configFile="config/TEMPLATE_math.xml" />
     <test testName="math-emu" configFile="config/TEMPLATE_math.xml" />
     <test testName="math-exec" configFile="config/TEMPLATE_math_exec.xml" />
     <test testName="math-funnelshift" configFile="config/TEMPLATE_math_funnelshift.xml" />

--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -28,7 +28,7 @@ exec_tests = ['thrust-vector-2', 'thrust-binary-search', 'thrust-count', 'thrust
              'user_defined_rules', 'math-exec', 'math-saturatef', 'math-habs', 'cudnn-activation',
              'cudnn-fill', 'cudnn-lrn', 'cudnn-memory', 'cudnn-pooling', 'cudnn-reorder', 'cudnn-scale', 'cudnn-softmax',
              'cudnn-sum', 'math-funnelshift', 'ccl', 'thrust-sort_by_key', 'thrust-find', 'thrust-inner_product', 'thrust-reduce_by_key',
-             'math-bfloat16', 'libcu_atomic', 'test_shared_memory', 'cudnn-reduction', 'cudnn-binary', 'cudnn-bnp1', 'cudnn-bnp2', 'cudnn-bnp3',
+             'math-bfloat16', "math-drcp", 'libcu_atomic', 'test_shared_memory', 'cudnn-reduction', 'cudnn-binary', 'cudnn-bnp1', 'cudnn-bnp2', 'cudnn-bnp3',
              'cudnn-normp1', 'cudnn-normp2', 'cudnn-normp3', 'cudnn-convp1', 'cudnn-convp2', 'cudnn-convp3', 'cudnn-convp4', 'cudnn-convp5',
              'thrust-unique_by_key', 'cufft_test']
 


### PR DESCRIPTION
Signed-off-by: Lu, John <john.lu@intel.com>

Ensure that drcp* intrinsics are migrated with 64-bit accuracy.
Thus, do not use sycl::native::recip, but generate a standard C-expression (1.0/(X)).
Generated code still does not preserve rounding mode.