### PR TITLE
[SYCLomatic] Replace sycl::access::target::local used in test case with sycl::local_accessor

### DIFF
--- a/help_function/src/memory_management_test2.cpp
+++ b/help_function/src/memory_management_test2.cpp
@@ -540,7 +540,7 @@ void test9() {
     dpct::get_default_queue().submit(
       [&](sycl::handler &cgh) {
       sycl::range<2> acc_range(Num, Num);
-      sycl::accessor<float, 2, sycl::access_mode::read_write, sycl::access::target::local> C_local_acc(acc_range, cgh);
+      sycl::local_accessor<float, 2> C_local_acc(acc_range, cgh);
       auto A = buffer_A.get_access<sycl::access::mode::read_write>(cgh);
 
         cgh.parallel_for(


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>