### PR TITLE
[SYCLomatic #223] Add and update test cases about new option use-dpcpp-extensions

### DIFF
--- a/behavior_tests/behavior_tests.xml
+++ b/behavior_tests/behavior_tests.xml
@@ -148,6 +148,7 @@
         <test testName="bt-analysis-scope-path3" configFile="config/TEMPLATE_behavior_tests.xml" />
         <test testName="bt-analysis-scope-path4" configFile="config/TEMPLATE_behavior_tests.xml" />
         <test testName="ngt-analysis-scope-path1" configFile="config/TEMPLATE_behavior_tests.xml" />
+        <test testName="ngt-use-dpcpp-extensions" configFile="config/TEMPLATE_behavior_tests.xml" />
         <test testName="bt-check-install-files" configFile="config/TEMPLATE_behavior_tests.xml" />
         <test testName="bt-deprecate-custom-helper" configFile="config/TEMPLATE_behavior_tests.xml" />
         <test testName="bt-check-c2s" configFile="config/TEMPLATE_behavior_tests.xml" />

--- a/behavior_tests/src/bt-autocomplete/do_test.py
+++ b/behavior_tests/src/bt-autocomplete/do_test.py
@@ -147,6 +147,7 @@ def migrate_test():
                 '--suppress-warnings-all\n' + \
                 '--sycl-named-lambda\n' + \
                 '--use-custom-helper=\n' + \
+                '--use-dpcpp-extensions=\n' + \
                 '--use-experimental-features=\n' + \
                 '--use-explicit-namespace=\n' + \
                 '--usm-level=\n' + \

--- a/behavior_tests/src/ngt-use-dpcpp-extensions/do_test.py
+++ b/behavior_tests/src/ngt-use-dpcpp-extensions/do_test.py
@@ -1,0 +1,30 @@
+# ====------ do_test.py---------- *- Python -* ----------------------------===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===#
+import subprocess
+import platform
+import os
+import sys
+from test_config import CT_TOOL
+
+from test_utils import *
+
+def setup_test():
+    change_dir(test_config.current_test)
+    return True
+
+def migrate_test():
+
+    call_subprocess(test_config.CT_TOOL + " --cuda-include-path=" + test_config.include_path +
+        " --use-dpcpp-extensions=abc")
+    return is_sub_string("Cannot find option named 'abc'", test_config.command_output)
+
+def build_test():
+    return True
+
+def run_test():
+    return True


### PR DESCRIPTION
1. Update the test bt-autocomplete
2. Add new negative test ngt-use-dpcpp-extensions

Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>