### PR TITLE
[SYCLomatic] adding make_transform_output_iterator tests

### DIFF
--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -127,6 +127,7 @@
     <test testName="onedpl_test_tabulate" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_transform_if" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_transform" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="onedpl_test_transform_output_iterator" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_transform_reduce" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />
     <test testName="onedpl_test_translate_key" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />
     <test testName="onedpl_test_uninitialized_fill" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />

--- a/help_function/src/onedpl_test_transform_output_iterator.cpp
+++ b/help_function/src/onedpl_test_transform_output_iterator.cpp
@@ -154,16 +154,16 @@ struct test_type_shift
     operator()(size_t buffer_size)
     {
 
-        double init = 0.5;
-        std::vector<double> source(buffer_size, init);
+        float init = 0.5f;
+        std::vector<float> source(buffer_size, init);
         std::vector<int> res(buffer_size, 0);
 
-        dpct::device_vector<double> sycl_source(source.begin(), source.end());
+        dpct::device_vector<float> sycl_source(source.begin(), source.end());
         dpct::device_vector<int> sycl_result(res.begin(), res.end());
 
         // 3. run algorithms
         auto transformation1 = [](float item) { return (int)(item * 2.0f); };
-        auto transformation2 = [](double item) { return (float)(item + 1.0); };
+        auto transformation2 = [](float item) { return item + 1.0f; };
 
         auto tr1_host_result_begin = dpct::make_transform_output_iterator(sycl_result.begin(), transformation1);
         auto tr2_host_result_begin = dpct::make_transform_output_iterator(tr1_host_result_begin, transformation2);

--- a/help_function/src/onedpl_test_transform_output_iterator.cpp
+++ b/help_function/src/onedpl_test_transform_output_iterator.cpp
@@ -185,9 +185,9 @@ struct test_zip_iterator
     {
 
         float init = 2.0f;
-        std::vector<int> source(buffer_size, init);
-        std::vector<int> res1(buffer_size, 0.0f);
-        std::vector<int> res2(buffer_size, 0.0f);
+        std::vector<float> source(buffer_size, init);
+        std::vector<float> res1(buffer_size, 0.0f);
+        std::vector<float> res2(buffer_size, 0.0f);
 
         dpct::device_vector<float> sycl_source(source.begin(), source.end());
         dpct::device_vector<float> sycl_result1(res1.begin(), res1.end());

--- a/help_function/src/onedpl_test_transform_output_iterator.cpp
+++ b/help_function/src/onedpl_test_transform_output_iterator.cpp
@@ -14,9 +14,8 @@
 #include "dpct/dpct.hpp"
 #include "dpct/dpl_utils.hpp"
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
-#include <iomanip>
 #include <iostream>
 
 // verification utilities

--- a/help_function/src/onedpl_test_transform_output_iterator.cpp
+++ b/help_function/src/onedpl_test_transform_output_iterator.cpp
@@ -89,10 +89,8 @@ struct test_simple_copy
 
         ::std::vector<int> expected_res(buffer_size, identity + 1);
 
-        return test_copy(oneapi::dpl::execution::make_device_policy(
-                             oneapi::dpl::execution::make_device_policy(dpct::get_default_queue())),
-                         sycl_source.begin(), sycl_source.end(), tr_host_result_begin, sycl_result.begin(),
-                         expected_res.begin());
+        return test_copy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), sycl_source.begin(),
+                         sycl_source.end(), tr_host_result_begin, sycl_result.begin(), expected_res.begin());
     }
 };
 
@@ -119,8 +117,7 @@ struct test_multi_transform_copy
 
         ::std::vector<int> expected_res(buffer_size, ((identity + 3) * 2) + 1);
 
-        return test_copy(oneapi::dpl::execution::make_device_policy(
-                             oneapi::dpl::execution::make_device_policy(dpct::get_default_queue())),
+        return test_copy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue())),
                          sycl_source.begin(), sycl_source.end(), tr3_sycl_result_begin, sycl_result.begin(),
                          expected_res.begin());
     }

--- a/help_function/src/onedpl_test_transform_output_iterator.cpp
+++ b/help_function/src/onedpl_test_transform_output_iterator.cpp
@@ -117,7 +117,7 @@ struct test_multi_transform_copy
 
         ::std::vector<int> expected_res(buffer_size, ((identity + 3) * 2) + 1);
 
-        return test_copy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue())),
+        return test_copy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
                          sycl_source.begin(), sycl_source.end(), tr3_sycl_result_begin, sycl_result.begin(),
                          expected_res.begin());
     }

--- a/help_function/src/onedpl_test_transform_output_iterator.cpp
+++ b/help_function/src/onedpl_test_transform_output_iterator.cpp
@@ -1,0 +1,441 @@
+// ====------ onedpl_test_transform_output_iterator.cpp-- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/execution"
+#include "oneapi/dpl/iterator"
+
+#include "dpct/dpct.hpp"
+#include "dpct/dpl_utils.hpp"
+
+#include <CL/sycl.hpp>
+
+#include <iomanip>
+#include <iostream>
+
+// verification utilities
+
+template <typename String, typename _T1, typename _T2>
+int ASSERT_EQUAL(_T1 &&X, _T2 &&Y, String msg) {
+  if (X != Y) {
+    std::cout << "FAIL: " << msg << " - (" << X << "," << Y << ")" << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+template <typename String, typename _T1, typename _T2>
+int ASSERT_EQUAL_N(_T1 &&X, _T2 &&Y, ::std::size_t n, String msg) {
+  int failed_tests = 0;
+  for (size_t i = 0; i < n; i++) {
+    failed_tests += ASSERT_EQUAL(*X, *Y, msg);
+    X++;
+    Y++;
+  }
+  return failed_tests;
+}
+
+int test_passed(int failing_elems, std::string test_name) {
+  if (failing_elems == 0) {
+    std::cout << "PASS: " << test_name << std::endl;
+    return 0;
+  }
+  return 1;
+}
+
+template <typename ExecutionPolicy, typename Iterator1, typename Iterator2,
+          typename Size, typename Iterator3, typename Iterator4>
+int test_copy(ExecutionPolicy &&exec, Iterator1 first1, Iterator1 last1,
+              Iterator2 first2, Iterator3 result, Size n,
+              Iterator4 expected_values) {
+
+  ::std::copy(::std::forward<ExecutionPolicy>(exec), first1, last1, first2);
+  // result is the base iterator for the transform_output_iterator
+  // first2
+  return ASSERT_EQUAL_N(
+      expected_values, result, n,
+      "Wrong result from copy with transform_output_iterator");
+}
+
+struct test_simple_copy {
+  int operator()(size_t buffer_size) {
+
+    sycl::queue q{};
+
+    auto sycl_source_begin = sycl::malloc_shared<int>(buffer_size, q);
+    auto sycl_result_begin = sycl::malloc_shared<int>(buffer_size, q);
+
+    auto transformation = [](int item) { return item + 1; };
+
+    int identity = 0;
+    ::std::fill_n(sycl_source_begin, buffer_size, identity);
+    auto tr_host_result_begin =
+        dpct::make_transform_output_iterator(sycl_result_begin, transformation);
+
+    ::std::vector<int> expected_res(buffer_size, identity + 1);
+
+    return test_copy(oneapi::dpl::execution::make_device_policy(q),
+                     sycl_source_begin, sycl_source_begin + buffer_size,
+                     tr_host_result_begin, sycl_result_begin, buffer_size,
+                     expected_res.begin());
+  }
+};
+
+struct test_multi_transform_copy {
+  int operator()(size_t buffer_size) {
+
+    sycl::queue q{};
+
+    auto sycl_source_begin = sycl::malloc_shared<int>(buffer_size, q);
+    auto sycl_result_begin = sycl::malloc_shared<int>(buffer_size, q);
+
+    auto transformation1 = [](int item) { return item + 1; };
+    auto transformation2 = [](int item) { return item * 2; };
+    auto transformation3 = [](int item) { return item + 3; };
+
+    int identity = 0;
+    ::std::fill_n(sycl_source_begin, buffer_size, identity);
+    auto tr_sycl_result_begin = dpct::make_transform_output_iterator(
+        sycl_result_begin, transformation1);
+    auto tr2_sycl_result_begin = dpct::make_transform_output_iterator(
+        tr_sycl_result_begin, transformation2);
+    auto tr3_sycl_result_begin = dpct::make_transform_output_iterator(
+        tr2_sycl_result_begin, transformation3);
+
+    ::std::vector<int> expected_res(buffer_size, ((identity + 3) * 2) + 1);
+
+    return test_copy(oneapi::dpl::execution::make_device_policy(q),
+                     sycl_source_begin, sycl_source_begin + buffer_size,
+                     tr3_sycl_result_begin, sycl_result_begin, buffer_size,
+                     expected_res.begin());
+  }
+};
+
+struct test_fill_transform {
+  int operator()(size_t buffer_size) {
+
+    sycl::queue q{};
+    auto sycl_source_begin = sycl::malloc_shared<int>(buffer_size, q);
+    auto sycl_result_begin = sycl::malloc_shared<int>(buffer_size, q);
+
+    auto transformation = [](int item) { return item + 1; };
+
+    int identity = 0;
+    {
+      auto tr_source_begin = dpct::make_transform_output_iterator(
+          sycl_source_begin, transformation);
+      ::std::fill_n(tr_source_begin, buffer_size, identity);
+    }
+
+    ::std::vector<int> expected_res(buffer_size, identity + 1);
+
+    return ASSERT_EQUAL_N(
+        expected_res.begin(), sycl_source_begin, buffer_size,
+        "Wrong result from fill with transform_output_iterator");
+  }
+};
+
+struct test_type_shift {
+  int operator()(size_t buffer_size) {
+
+    sycl::queue q{};
+
+    auto sycl_source_begin = sycl::malloc_shared<double>(buffer_size, q);
+    auto sycl_result_begin = sycl::malloc_shared<int>(buffer_size, q);
+
+    // 3. run algorithms
+    auto transformation1 = [](float item) { return (int)(item * 2.0f); };
+    auto transformation2 = [](double item) { return (float)(item + 1.0); };
+
+    double init = 0.5;
+
+    ::std::fill_n(sycl_source_begin, buffer_size, init);
+
+    auto tr1_host_result_begin = oneapi::dpl::make_transform_output_iterator(
+        sycl_result_begin, transformation1);
+    auto tr2_host_result_begin = oneapi::dpl::make_transform_output_iterator(
+        tr1_host_result_begin, transformation2);
+
+    ::std::vector<int> expected_res(buffer_size,
+                                    (int)((float)(init + 1.0) * 2.0f));
+
+    return test_copy(oneapi::dpl::execution::make_device_policy(q),
+                     sycl_source_begin, sycl_source_begin + buffer_size,
+                     tr2_host_result_begin, sycl_result_begin, buffer_size,
+                     expected_res.begin());
+  }
+};
+
+struct test_zip_iterator {
+  int operator()(size_t buffer_size) {
+
+    sycl::queue q{};
+
+    auto sycl_source_begin = sycl::malloc_shared<float>(buffer_size, q);
+    auto sycl_result_begin1 = sycl::malloc_shared<float>(buffer_size, q);
+    auto sycl_result_begin2 = sycl::malloc_shared<float>(buffer_size, q);
+
+    auto zip =
+        oneapi::dpl::make_zip_iterator(sycl_result_begin1, sycl_result_begin2);
+
+    auto transformation1 = [](const auto &item) {
+      return ::std::make_tuple(item - 1.0f, item * item);
+    };
+    auto tr1_host_result_begin =
+        dpct::make_transform_output_iterator(zip, transformation1);
+
+    float init = 2.0f;
+
+    ::std::fill_n(sycl_source_begin, buffer_size, init);
+
+    ::std::vector<float> expected_res1(buffer_size, init - 1.0f);
+    ::std::vector<float> expected_res2(buffer_size, init * init);
+    auto zip_res = oneapi::dpl::make_zip_iterator(expected_res1.begin(),
+                                                  expected_res2.begin());
+
+    ::std::copy(oneapi::dpl::execution::make_device_policy(q),
+                sycl_source_begin, sycl_source_begin + buffer_size,
+                tr1_host_result_begin);
+
+    int failed_tests = 0;
+    failed_tests +=
+        ASSERT_EQUAL_N(expected_res1.begin(), sycl_result_begin1, buffer_size,
+                       "Wrong result from copy with transform_output_iterator");
+    failed_tests +=
+        ASSERT_EQUAL_N(expected_res2.begin(), sycl_result_begin2, buffer_size,
+                       "Wrong result from copy with transform_output_iterator");
+
+    return failed_tests;
+  }
+};
+
+template <typename OutputIterator1, typename UnaryFunc>
+auto attempt_to_dangle(OutputIterator1 out1, UnaryFunc unary) {
+  auto toi = oneapi::dpl::make_transform_output_iterator(out1, unary);
+  // Leave scope of the transform output iterator, then assign data
+  // to the wrapper after the fact.
+  return *toi;
+}
+
+template <typename ExecutionPolicy, typename OutputIterator1,
+          typename InputIterator, typename Size, typename Iterator3,
+          typename UnaryFunc>
+int dangle_test(ExecutionPolicy &&exec, OutputIterator1 first1,
+                OutputIterator1 last1, InputIterator input, Size n,
+                Iterator3 expected_values, UnaryFunc unary) {
+  auto num_eles = last1 - first1;
+  oneapi::dpl::counting_iterator<::std::size_t> count_first(0UL);
+  oneapi::dpl::counting_iterator<::std::size_t> count_last(num_eles);
+  std::for_each(::std::forward<ExecutionPolicy>(exec), count_first, count_last,
+                [=](const auto &elem) {
+                  auto wrapper = attempt_to_dangle(first1 + elem, unary);
+                  // assigning to wrapper object after
+                  // transform_iterator leaves
+                  // scope with zip iter
+                  wrapper = input[elem];
+                });
+
+  return ASSERT_EQUAL_N(
+      expected_values, first1, n,
+      "Wrong result from usage of transform_output_iterator (dangle_test) ");
+}
+
+struct test_dangling_ref {
+  int operator()(size_t buffer_size) {
+
+    sycl::queue q{};
+
+    auto sycl_source_begin = sycl::malloc_shared<float>(buffer_size, q);
+    auto sycl_result_begin = sycl::malloc_shared<float>(buffer_size, q);
+
+    float init = 2.0f;
+
+    ::std::fill_n(sycl_source_begin, buffer_size, init);
+
+    ::std::vector<float> expected_res(buffer_size, init * init);
+
+    auto transformation1 = [](const auto &item) { return item * item; };
+
+    return dangle_test(oneapi::dpl::execution::make_device_policy(q),
+                       sycl_result_begin, sycl_result_begin + buffer_size,
+                       sycl_source_begin, buffer_size, expected_res.begin(),
+                       transformation1);
+  }
+};
+
+template <typename OutputIterator1, typename UnaryFunc1, typename UnaryFunc2>
+auto attempt_to_dangle_chain(OutputIterator1 out1, UnaryFunc1 unary1,
+                             UnaryFunc2 unary2) {
+  auto toi1 = oneapi::dpl::make_transform_output_iterator(out1, unary1);
+  auto toi2 = oneapi::dpl::make_transform_output_iterator(toi1, unary2);
+  // leave scope of the transform output iterator, then assign
+  // data to the wrapper after the fact.
+  return *toi2;
+}
+
+template <typename ExecutionPolicy, typename OutputIterator1,
+          typename InputIterator, typename Size, typename Iterator3,
+          typename UnaryFunc1, typename UnaryFunc2>
+int chain_dangle_test(ExecutionPolicy &&exec, OutputIterator1 first1,
+                      OutputIterator1 last1, InputIterator input, Size n,
+                      Iterator3 expected_values, UnaryFunc1 unary1,
+                      UnaryFunc2 unary2) {
+  auto num_eles = last1 - first1;
+  oneapi::dpl::counting_iterator<::std::size_t> count_first(0UL);
+  oneapi::dpl::counting_iterator<::std::size_t> count_last(num_eles);
+  std::for_each(::std::forward<ExecutionPolicy>(exec), count_first, count_last,
+                [=](const auto &elem) {
+                  auto wrapper =
+                      attempt_to_dangle_chain(first1 + elem, unary1, unary2);
+                  // assigning to wrapper object after transform_iterators
+                  // leaves scope
+                  wrapper = input[elem];
+                });
+
+  return ASSERT_EQUAL_N(expected_values, first1, n,
+                        "Wrong result from usage of transform_output_iterator "
+                        "(chain_dangle_test) ");
+}
+
+struct test_dangling_chain_ref {
+  int operator()(size_t buffer_size) {
+
+    sycl::queue q{};
+
+    auto sycl_source_begin = sycl::malloc_shared<float>(buffer_size, q);
+    auto sycl_result_begin = sycl::malloc_shared<float>(buffer_size, q);
+
+    float init = 2.0f;
+
+    ::std::fill_n(sycl_source_begin, buffer_size, init);
+
+    ::std::vector<float> expected_res(buffer_size, (init * init) - 2.0f);
+
+    auto transformation1 = [](const auto &item) { return item - 2.0f; };
+    auto transformation2 = [](const auto &item) { return item * item; };
+
+    return chain_dangle_test(
+        oneapi::dpl::execution::make_device_policy(q), sycl_result_begin,
+        sycl_result_begin + buffer_size, sycl_source_begin, buffer_size,
+        expected_res.begin(), transformation1, transformation2);
+  }
+};
+
+template <typename OutputIterator1, typename OutputIterator2,
+          typename UnaryFunc>
+auto attempt_to_dangle_zip(OutputIterator1 out1, OutputIterator2 out2,
+                           UnaryFunc unary) {
+  auto zip = oneapi::dpl::make_zip_iterator(out1, out2);
+  auto toi = oneapi::dpl::make_transform_output_iterator(zip, unary);
+  // leave scope of the transform output iterator, then assign data to the
+  // wrapper after the fact.
+  return *toi;
+}
+
+template <typename ExecutionPolicy, typename OutputIterator1,
+          typename OutputIterator2, typename InputIterator, typename Size,
+          typename Iterator3, typename Iterator4, typename UnaryFunc>
+int zip_dangle_test(ExecutionPolicy &&exec, OutputIterator1 first1,
+                    OutputIterator1 last1, OutputIterator2 first2,
+                    InputIterator input, Size n, Iterator3 expected_values1,
+                    Iterator4 expected_values2, UnaryFunc unary) {
+  auto num_eles = last1 - first1;
+  oneapi::dpl::counting_iterator<::std::size_t> count_first(0UL);
+  oneapi::dpl::counting_iterator<::std::size_t> count_last(num_eles);
+  std::for_each(::std::forward<ExecutionPolicy>(exec), count_first, count_last,
+                [=](const auto &elem) {
+                  auto wrapper = attempt_to_dangle_zip(first1 + elem,
+                                                       first2 + elem, unary);
+                  // assigning to wrapper object after transform_iterator leaves
+                  // scope
+                  wrapper = input[elem];
+                });
+  auto zip_output = oneapi::dpl::make_zip_iterator(first1, first2);
+
+  int falied_tests = 0;
+  falied_tests +=
+      ASSERT_EQUAL_N(expected_values1, first1, n,
+                     "Wrong result from usage of transform_output_iterator "
+                     "(zip_dangle_test) ");
+  falied_tests +=
+      ASSERT_EQUAL_N(expected_values2, first2, n,
+                     "Wrong result from usage of transform_output_iterator "
+                     "(zip_dangle_test) ");
+  return falied_tests;
+}
+
+struct test_dangling_zip_ref {
+  int operator()(size_t buffer_size) {
+
+    sycl::queue q{};
+
+    auto sycl_source_begin = sycl::malloc_shared<float>(buffer_size, q);
+    auto sycl_result_begin1 = sycl::malloc_shared<float>(buffer_size, q);
+    auto sycl_result_begin2 = sycl::malloc_shared<float>(buffer_size, q);
+
+    float init = 2.0f;
+
+    ::std::fill_n(sycl_source_begin, buffer_size, init);
+
+    ::std::vector<float> expected_res1(buffer_size, init - 1.0f);
+    ::std::vector<float> expected_res2(buffer_size, init * init);
+    auto zip_res = oneapi::dpl::make_zip_iterator(expected_res1.begin(),
+                                                  expected_res2.begin());
+
+    auto transformation1 = [](const auto &item) {
+      return ::std::make_tuple(item - 1.0f, item * item);
+    };
+
+    return zip_dangle_test(oneapi::dpl::execution::make_device_policy(q),
+                           sycl_result_begin1, sycl_result_begin1 + buffer_size,
+                           sycl_result_begin2, sycl_source_begin, buffer_size,
+                           expected_res1.begin(), expected_res2.begin(),
+                           transformation1);
+  }
+};
+
+template <typename TestFunctor>
+int RunTest(TestFunctor test, size_t max_n, ::std::string msg) {
+  int failed_tests = 0;
+  for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n)) {
+    failed_tests += test(n);
+  }
+  return test_passed(failed_tests, msg);
+}
+
+int main() {
+
+  // used to detect failures
+
+  int test_suites_failed = 0;
+  size_t max_n = 10000;
+
+  test_suites_failed += RunTest(test_simple_copy(), max_n, "Simple Copy");
+  test_suites_failed +=
+      RunTest(test_multi_transform_copy(), max_n, "Multiple Transforms");
+  test_suites_failed +=
+      RunTest(test_fill_transform(), max_n, "Simple Host Fill");
+  test_suites_failed +=
+      RunTest(test_type_shift(), max_n, "Type Shifting Transform");
+  test_suites_failed +=
+      RunTest(test_zip_iterator(), max_n, "Zip Iterator Transform");
+  test_suites_failed +=
+      RunTest(test_dangling_ref(), max_n, "Checking Reference Not Dangled");
+  test_suites_failed += RunTest(test_dangling_chain_ref(), max_n,
+                                "Checking Reference Not Dangled Chain");
+  test_suites_failed += RunTest(test_dangling_zip_ref(), max_n,
+                                "Checking Reference Not Dangled Zip");
+
+  std::cout << std::endl
+            << test_suites_failed << " failing test(s) detected." << std::endl;
+  if (test_suites_failed == 0) {
+    return 0;
+  }
+  return 1;
+}

--- a/help_function/src/onedpl_test_transform_output_iterator.cpp
+++ b/help_function/src/onedpl_test_transform_output_iterator.cpp
@@ -49,39 +49,39 @@ int test_passed(int failing_elems, std::string test_name) {
 }
 
 template <typename ExecutionPolicy, typename Iterator1, typename Iterator2,
-          typename Size, typename Iterator3, typename Iterator4>
+          typename Iterator3, typename Iterator4>
 int test_copy(ExecutionPolicy &&exec, Iterator1 first1, Iterator1 last1,
-              Iterator2 first2, Iterator3 result, Size n,
+              Iterator2 first2, Iterator3 result,
               Iterator4 expected_values) {
 
   ::std::copy(::std::forward<ExecutionPolicy>(exec), first1, last1, first2);
   // result is the base iterator for the transform_output_iterator
   // first2
   return ASSERT_EQUAL_N(
-      expected_values, result, n,
+      expected_values, result, last1 - first1,
       "Wrong result from copy with transform_output_iterator");
 }
 
 struct test_simple_copy {
   int operator()(size_t buffer_size) {
 
-    sycl::queue q{};
+    int identity = 0;
+    std::vector<int> source(buffer_size, identity);
+    std::vector<int> res(buffer_size, identity);
 
-    auto sycl_source_begin = sycl::malloc_shared<int>(buffer_size, q);
-    auto sycl_result_begin = sycl::malloc_shared<int>(buffer_size, q);
+    dpct::device_vector<int> sycl_source(source.begin(), source.end());
+    dpct::device_vector<int> sycl_result(res.begin(), res.end());
 
     auto transformation = [](int item) { return item + 1; };
 
-    int identity = 0;
-    ::std::fill_n(sycl_source_begin, buffer_size, identity);
     auto tr_host_result_begin =
-        dpct::make_transform_output_iterator(sycl_result_begin, transformation);
+        dpct::make_transform_output_iterator(sycl_result.begin(), transformation);
 
     ::std::vector<int> expected_res(buffer_size, identity + 1);
 
-    return test_copy(oneapi::dpl::execution::make_device_policy(q),
-                     sycl_source_begin, sycl_source_begin + buffer_size,
-                     tr_host_result_begin, sycl_result_begin, buffer_size,
+    return test_copy(oneapi::dpl::execution::make_device_policy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue())),
+                     sycl_source.begin(), sycl_source.end(),
+                     tr_host_result_begin, sycl_result.begin(),
                      expected_res.begin());
   }
 };
@@ -89,19 +89,19 @@ struct test_simple_copy {
 struct test_multi_transform_copy {
   int operator()(size_t buffer_size) {
 
-    sycl::queue q{};
+    int identity = 0;
+    std::vector<int> source(buffer_size, identity);
+    std::vector<int> res(buffer_size, identity);
 
-    auto sycl_source_begin = sycl::malloc_shared<int>(buffer_size, q);
-    auto sycl_result_begin = sycl::malloc_shared<int>(buffer_size, q);
+    dpct::device_vector<int> sycl_source(source.begin(), source.end());
+    dpct::device_vector<int> sycl_result(res.begin(), res.end());
 
     auto transformation1 = [](int item) { return item + 1; };
     auto transformation2 = [](int item) { return item * 2; };
     auto transformation3 = [](int item) { return item + 3; };
 
-    int identity = 0;
-    ::std::fill_n(sycl_source_begin, buffer_size, identity);
     auto tr_sycl_result_begin = dpct::make_transform_output_iterator(
-        sycl_result_begin, transformation1);
+        sycl_result.begin(), transformation1);
     auto tr2_sycl_result_begin = dpct::make_transform_output_iterator(
         tr_sycl_result_begin, transformation2);
     auto tr3_sycl_result_begin = dpct::make_transform_output_iterator(
@@ -109,9 +109,9 @@ struct test_multi_transform_copy {
 
     ::std::vector<int> expected_res(buffer_size, ((identity + 3) * 2) + 1);
 
-    return test_copy(oneapi::dpl::execution::make_device_policy(q),
-                     sycl_source_begin, sycl_source_begin + buffer_size,
-                     tr3_sycl_result_begin, sycl_result_begin, buffer_size,
+    return test_copy(oneapi::dpl::execution::make_device_policy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue())),
+                     sycl_source.begin(), sycl_source.end(),
+                     tr3_sycl_result_begin, sycl_result.begin(),
                      expected_res.begin());
   }
 };
@@ -119,23 +119,23 @@ struct test_multi_transform_copy {
 struct test_fill_transform {
   int operator()(size_t buffer_size) {
 
-    sycl::queue q{};
-    auto sycl_source_begin = sycl::malloc_shared<int>(buffer_size, q);
-    auto sycl_result_begin = sycl::malloc_shared<int>(buffer_size, q);
+    int identity = 0;
+    std::vector<int> res(buffer_size, identity);
+
+    dpct::device_vector<int> sycl_result(res.begin(), res.end());
 
     auto transformation = [](int item) { return item + 1; };
 
-    int identity = 0;
     {
       auto tr_source_begin = dpct::make_transform_output_iterator(
-          sycl_source_begin, transformation);
+          sycl_result.begin(), transformation);
       ::std::fill_n(tr_source_begin, buffer_size, identity);
     }
 
     ::std::vector<int> expected_res(buffer_size, identity + 1);
 
     return ASSERT_EQUAL_N(
-        expected_res.begin(), sycl_source_begin, buffer_size,
+        expected_res.begin(), sycl_result.begin(), buffer_size,
         "Wrong result from fill with transform_output_iterator");
   }
 };
@@ -143,30 +143,28 @@ struct test_fill_transform {
 struct test_type_shift {
   int operator()(size_t buffer_size) {
 
-    sycl::queue q{};
+    double init = 0.5;
+    std::vector<double> source(buffer_size, init);
+    std::vector<int> res(buffer_size, 0);
 
-    auto sycl_source_begin = sycl::malloc_shared<double>(buffer_size, q);
-    auto sycl_result_begin = sycl::malloc_shared<int>(buffer_size, q);
+    dpct::device_vector<double> sycl_source(source.begin(), source.end());
+    dpct::device_vector<int> sycl_result(res.begin(), res.end());
 
     // 3. run algorithms
     auto transformation1 = [](float item) { return (int)(item * 2.0f); };
     auto transformation2 = [](double item) { return (float)(item + 1.0); };
 
-    double init = 0.5;
-
-    ::std::fill_n(sycl_source_begin, buffer_size, init);
-
-    auto tr1_host_result_begin = oneapi::dpl::make_transform_output_iterator(
-        sycl_result_begin, transformation1);
-    auto tr2_host_result_begin = oneapi::dpl::make_transform_output_iterator(
+    auto tr1_host_result_begin = dpct::make_transform_output_iterator(
+        sycl_result.begin(), transformation1);
+    auto tr2_host_result_begin = dpct::make_transform_output_iterator(
         tr1_host_result_begin, transformation2);
 
     ::std::vector<int> expected_res(buffer_size,
                                     (int)((float)(init + 1.0) * 2.0f));
 
-    return test_copy(oneapi::dpl::execution::make_device_policy(q),
-                     sycl_source_begin, sycl_source_begin + buffer_size,
-                     tr2_host_result_begin, sycl_result_begin, buffer_size,
+    return test_copy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+                     sycl_source.begin(), sycl_source.end(),
+                     tr2_host_result_begin, sycl_result.begin(),
                      expected_res.begin());
   }
 };
@@ -174,14 +172,17 @@ struct test_type_shift {
 struct test_zip_iterator {
   int operator()(size_t buffer_size) {
 
-    sycl::queue q{};
+    float init = 2.0f;
+    std::vector<int> source(buffer_size, init);
+    std::vector<int> res1(buffer_size, 0.0f);
+    std::vector<int> res2(buffer_size, 0.0f);
 
-    auto sycl_source_begin = sycl::malloc_shared<float>(buffer_size, q);
-    auto sycl_result_begin1 = sycl::malloc_shared<float>(buffer_size, q);
-    auto sycl_result_begin2 = sycl::malloc_shared<float>(buffer_size, q);
+    dpct::device_vector<float> sycl_source(source.begin(), source.end());
+    dpct::device_vector<float> sycl_result1(res1.begin(), res1.end());
+    dpct::device_vector<float> sycl_result2(res2.begin(), res2.end());
 
     auto zip =
-        oneapi::dpl::make_zip_iterator(sycl_result_begin1, sycl_result_begin2);
+        oneapi::dpl::make_zip_iterator(sycl_result1.begin(), sycl_result2.begin());
 
     auto transformation1 = [](const auto &item) {
       return ::std::make_tuple(item - 1.0f, item * item);
@@ -189,25 +190,21 @@ struct test_zip_iterator {
     auto tr1_host_result_begin =
         dpct::make_transform_output_iterator(zip, transformation1);
 
-    float init = 2.0f;
-
-    ::std::fill_n(sycl_source_begin, buffer_size, init);
-
     ::std::vector<float> expected_res1(buffer_size, init - 1.0f);
     ::std::vector<float> expected_res2(buffer_size, init * init);
     auto zip_res = oneapi::dpl::make_zip_iterator(expected_res1.begin(),
                                                   expected_res2.begin());
 
-    ::std::copy(oneapi::dpl::execution::make_device_policy(q),
-                sycl_source_begin, sycl_source_begin + buffer_size,
+    ::std::copy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+                sycl_source.begin(), sycl_source.end(),
                 tr1_host_result_begin);
 
     int failed_tests = 0;
     failed_tests +=
-        ASSERT_EQUAL_N(expected_res1.begin(), sycl_result_begin1, buffer_size,
+        ASSERT_EQUAL_N(expected_res1.begin(), sycl_result1.begin(), buffer_size,
                        "Wrong result from copy with transform_output_iterator");
     failed_tests +=
-        ASSERT_EQUAL_N(expected_res2.begin(), sycl_result_begin2, buffer_size,
+        ASSERT_EQUAL_N(expected_res2.begin(), sycl_result2.begin(), buffer_size,
                        "Wrong result from copy with transform_output_iterator");
 
     return failed_tests;
@@ -216,54 +213,51 @@ struct test_zip_iterator {
 
 template <typename OutputIterator1, typename UnaryFunc>
 auto attempt_to_dangle(OutputIterator1 out1, UnaryFunc unary) {
-  auto toi = oneapi::dpl::make_transform_output_iterator(out1, unary);
+  auto toi = dpct::make_transform_output_iterator(out1, unary);
   // Leave scope of the transform output iterator, then assign data
   // to the wrapper after the fact.
   return *toi;
 }
 
-template <typename ExecutionPolicy, typename OutputIterator1,
-          typename InputIterator, typename Size, typename Iterator3,
+template <typename ExecutionPolicy, typename InputIterator,
+          typename OutputIterator, typename Iterator3,
           typename UnaryFunc>
-int dangle_test(ExecutionPolicy &&exec, OutputIterator1 first1,
-                OutputIterator1 last1, InputIterator input, Size n,
-                Iterator3 expected_values, UnaryFunc unary) {
-  auto num_eles = last1 - first1;
+int dangle_test(ExecutionPolicy &&exec, InputIterator first, InputIterator last,
+                OutputIterator output_first, Iterator3 expected_values, 
+                UnaryFunc unary) {
+  auto num_eles = last - first;
   oneapi::dpl::counting_iterator<::std::size_t> count_first(0UL);
   oneapi::dpl::counting_iterator<::std::size_t> count_last(num_eles);
   std::for_each(::std::forward<ExecutionPolicy>(exec), count_first, count_last,
                 [=](const auto &elem) {
-                  auto wrapper = attempt_to_dangle(first1 + elem, unary);
-                  // assigning to wrapper object after
-                  // transform_iterator leaves
-                  // scope with zip iter
-                  wrapper = input[elem];
+                  auto wrapper = attempt_to_dangle(output_first + elem, unary);
+                  // Assigning to wrapper object after transform iterator
+                  //   leaves scope, still should perform transformation
+                  wrapper = first[elem];
                 });
 
   return ASSERT_EQUAL_N(
-      expected_values, first1, n,
+      expected_values, output_first, num_eles,
       "Wrong result from usage of transform_output_iterator (dangle_test) ");
 }
 
 struct test_dangling_ref {
   int operator()(size_t buffer_size) {
 
-    sycl::queue q{};
-
-    auto sycl_source_begin = sycl::malloc_shared<float>(buffer_size, q);
-    auto sycl_result_begin = sycl::malloc_shared<float>(buffer_size, q);
-
     float init = 2.0f;
+    std::vector<float> source(buffer_size, init);
+    std::vector<float> res(buffer_size, 0.0f);
 
-    ::std::fill_n(sycl_source_begin, buffer_size, init);
+    dpct::device_vector<float> sycl_source(source.begin(), source.end());
+    dpct::device_vector<float> sycl_result(res.begin(), res.end());
 
     ::std::vector<float> expected_res(buffer_size, init * init);
 
     auto transformation1 = [](const auto &item) { return item * item; };
 
-    return dangle_test(oneapi::dpl::execution::make_device_policy(q),
-                       sycl_result_begin, sycl_result_begin + buffer_size,
-                       sycl_source_begin, buffer_size, expected_res.begin(),
+    return dangle_test(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+                       sycl_source.begin(), sycl_source.end(),
+                       sycl_result.begin(), expected_res.begin(),
                        transformation1);
   }
 };
@@ -271,33 +265,32 @@ struct test_dangling_ref {
 template <typename OutputIterator1, typename UnaryFunc1, typename UnaryFunc2>
 auto attempt_to_dangle_chain(OutputIterator1 out1, UnaryFunc1 unary1,
                              UnaryFunc2 unary2) {
-  auto toi1 = oneapi::dpl::make_transform_output_iterator(out1, unary1);
-  auto toi2 = oneapi::dpl::make_transform_output_iterator(toi1, unary2);
+  auto toi1 = dpct::make_transform_output_iterator(out1, unary1);
+  auto toi2 = dpct::make_transform_output_iterator(toi1, unary2);
   // leave scope of the transform output iterator, then assign
   // data to the wrapper after the fact.
   return *toi2;
 }
 
-template <typename ExecutionPolicy, typename OutputIterator1,
-          typename InputIterator, typename Size, typename Iterator3,
+template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator, typename Iterator3,
           typename UnaryFunc1, typename UnaryFunc2>
-int chain_dangle_test(ExecutionPolicy &&exec, OutputIterator1 first1,
-                      OutputIterator1 last1, InputIterator input, Size n,
+int chain_dangle_test(ExecutionPolicy &&exec, InputIterator first,
+                      InputIterator last, OutputIterator output_first,
                       Iterator3 expected_values, UnaryFunc1 unary1,
                       UnaryFunc2 unary2) {
-  auto num_eles = last1 - first1;
+  auto num_eles = last - first;
   oneapi::dpl::counting_iterator<::std::size_t> count_first(0UL);
   oneapi::dpl::counting_iterator<::std::size_t> count_last(num_eles);
   std::for_each(::std::forward<ExecutionPolicy>(exec), count_first, count_last,
                 [=](const auto &elem) {
                   auto wrapper =
-                      attempt_to_dangle_chain(first1 + elem, unary1, unary2);
-                  // assigning to wrapper object after transform_iterators
+                      attempt_to_dangle_chain(output_first + elem, unary1, unary2);
+                  // assigning to wrapper object after transform iterator
                   // leaves scope
-                  wrapper = input[elem];
+                  wrapper = first[elem];
                 });
 
-  return ASSERT_EQUAL_N(expected_values, first1, n,
+  return ASSERT_EQUAL_N(expected_values, output_first, num_eles,
                         "Wrong result from usage of transform_output_iterator "
                         "(chain_dangle_test) ");
 }
@@ -305,14 +298,12 @@ int chain_dangle_test(ExecutionPolicy &&exec, OutputIterator1 first1,
 struct test_dangling_chain_ref {
   int operator()(size_t buffer_size) {
 
-    sycl::queue q{};
-
-    auto sycl_source_begin = sycl::malloc_shared<float>(buffer_size, q);
-    auto sycl_result_begin = sycl::malloc_shared<float>(buffer_size, q);
-
     float init = 2.0f;
+    std::vector<float> source(buffer_size, init);
+    std::vector<float> res(buffer_size, 0.0f);
 
-    ::std::fill_n(sycl_source_begin, buffer_size, init);
+    dpct::device_vector<float> sycl_source(source.begin(), source.end());
+    dpct::device_vector<float> sycl_result(res.begin(), res.end());
 
     ::std::vector<float> expected_res(buffer_size, (init * init) - 2.0f);
 
@@ -320,84 +311,11 @@ struct test_dangling_chain_ref {
     auto transformation2 = [](const auto &item) { return item * item; };
 
     return chain_dangle_test(
-        oneapi::dpl::execution::make_device_policy(q), sycl_result_begin,
-        sycl_result_begin + buffer_size, sycl_source_begin, buffer_size,
-        expected_res.begin(), transformation1, transformation2);
+        oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), sycl_source.begin(),
+        sycl_source.end(), sycl_result.begin(), expected_res.begin(), transformation1, transformation2);
   }
 };
 
-template <typename OutputIterator1, typename OutputIterator2,
-          typename UnaryFunc>
-auto attempt_to_dangle_zip(OutputIterator1 out1, OutputIterator2 out2,
-                           UnaryFunc unary) {
-  auto zip = oneapi::dpl::make_zip_iterator(out1, out2);
-  auto toi = oneapi::dpl::make_transform_output_iterator(zip, unary);
-  // leave scope of the transform output iterator, then assign data to the
-  // wrapper after the fact.
-  return *toi;
-}
-
-template <typename ExecutionPolicy, typename OutputIterator1,
-          typename OutputIterator2, typename InputIterator, typename Size,
-          typename Iterator3, typename Iterator4, typename UnaryFunc>
-int zip_dangle_test(ExecutionPolicy &&exec, OutputIterator1 first1,
-                    OutputIterator1 last1, OutputIterator2 first2,
-                    InputIterator input, Size n, Iterator3 expected_values1,
-                    Iterator4 expected_values2, UnaryFunc unary) {
-  auto num_eles = last1 - first1;
-  oneapi::dpl::counting_iterator<::std::size_t> count_first(0UL);
-  oneapi::dpl::counting_iterator<::std::size_t> count_last(num_eles);
-  std::for_each(::std::forward<ExecutionPolicy>(exec), count_first, count_last,
-                [=](const auto &elem) {
-                  auto wrapper = attempt_to_dangle_zip(first1 + elem,
-                                                       first2 + elem, unary);
-                  // assigning to wrapper object after transform_iterator leaves
-                  // scope
-                  wrapper = input[elem];
-                });
-  auto zip_output = oneapi::dpl::make_zip_iterator(first1, first2);
-
-  int falied_tests = 0;
-  falied_tests +=
-      ASSERT_EQUAL_N(expected_values1, first1, n,
-                     "Wrong result from usage of transform_output_iterator "
-                     "(zip_dangle_test) ");
-  falied_tests +=
-      ASSERT_EQUAL_N(expected_values2, first2, n,
-                     "Wrong result from usage of transform_output_iterator "
-                     "(zip_dangle_test) ");
-  return falied_tests;
-}
-
-struct test_dangling_zip_ref {
-  int operator()(size_t buffer_size) {
-
-    sycl::queue q{};
-
-    auto sycl_source_begin = sycl::malloc_shared<float>(buffer_size, q);
-    auto sycl_result_begin1 = sycl::malloc_shared<float>(buffer_size, q);
-    auto sycl_result_begin2 = sycl::malloc_shared<float>(buffer_size, q);
-
-    float init = 2.0f;
-
-    ::std::fill_n(sycl_source_begin, buffer_size, init);
-
-    ::std::vector<float> expected_res1(buffer_size, init - 1.0f);
-    ::std::vector<float> expected_res2(buffer_size, init * init);
-    auto zip_res = oneapi::dpl::make_zip_iterator(expected_res1.begin(),
-                                                  expected_res2.begin());
-
-    auto transformation1 = [](const auto &item) {
-      return ::std::make_tuple(item - 1.0f, item * item);
-    };
-
-    return zip_dangle_test(oneapi::dpl::execution::make_device_policy(q),
-                           sycl_result_begin1, sycl_result_begin1 + buffer_size,
-                           sycl_result_begin2, sycl_source_begin, buffer_size,
-                           expected_res1.begin(), expected_res2.begin(),
-                           transformation1);
-  }
-};
 
 template <typename TestFunctor>
 int RunTest(TestFunctor test, size_t max_n, ::std::string msg) {
@@ -428,8 +346,6 @@ int main() {
       RunTest(test_dangling_ref(), max_n, "Checking Reference Not Dangled");
   test_suites_failed += RunTest(test_dangling_chain_ref(), max_n,
                                 "Checking Reference Not Dangled Chain");
-  test_suites_failed += RunTest(test_dangling_zip_ref(), max_n,
-                                "Checking Reference Not Dangled Zip");
 
   std::cout << std::endl
             << test_suites_failed << " failing test(s) detected." << std::endl;

--- a/help_function/src/onedpl_test_transform_output_iterator.cpp
+++ b/help_function/src/onedpl_test_transform_output_iterator.cpp
@@ -21,336 +21,341 @@
 // verification utilities
 
 template <typename String, typename _T1, typename _T2>
-int ASSERT_EQUAL(_T1 &&X, _T2 &&Y, String msg) {
-  if (X != Y) {
-    std::cout << "FAIL: " << msg << " - (" << X << "," << Y << ")" << std::endl;
-    return 1;
-  }
-  return 0;
+int
+ASSERT_EQUAL(_T1&& X, _T2&& Y, String msg)
+{
+    if (X != Y)
+    {
+        std::cout << "FAIL: " << msg << " - (" << X << "," << Y << ")" << std::endl;
+        return 1;
+    }
+    return 0;
 }
 
 template <typename String, typename _T1, typename _T2>
-int ASSERT_EQUAL_N(_T1 &&X, _T2 &&Y, ::std::size_t n, String msg) {
-  int failed_tests = 0;
-  for (size_t i = 0; i < n; i++) {
-    failed_tests += ASSERT_EQUAL(*X, *Y, msg);
-    X++;
-    Y++;
-  }
-  return failed_tests;
-}
-
-int test_passed(int failing_elems, std::string test_name) {
-  if (failing_elems == 0) {
-    std::cout << "PASS: " << test_name << std::endl;
-    return 0;
-  }
-  return 1;
-}
-
-template <typename ExecutionPolicy, typename Iterator1, typename Iterator2,
-          typename Iterator3, typename Iterator4>
-int test_copy(ExecutionPolicy &&exec, Iterator1 first1, Iterator1 last1,
-              Iterator2 first2, Iterator3 result,
-              Iterator4 expected_values) {
-
-  ::std::copy(::std::forward<ExecutionPolicy>(exec), first1, last1, first2);
-  // result is the base iterator for the transform_output_iterator
-  // first2
-  return ASSERT_EQUAL_N(
-      expected_values, result, last1 - first1,
-      "Wrong result from copy with transform_output_iterator");
-}
-
-struct test_simple_copy {
-  int operator()(size_t buffer_size) {
-
-    int identity = 0;
-    std::vector<int> source(buffer_size, identity);
-    std::vector<int> res(buffer_size, identity);
-
-    dpct::device_vector<int> sycl_source(source.begin(), source.end());
-    dpct::device_vector<int> sycl_result(res.begin(), res.end());
-
-    auto transformation = [](int item) { return item + 1; };
-
-    auto tr_host_result_begin =
-        dpct::make_transform_output_iterator(sycl_result.begin(), transformation);
-
-    ::std::vector<int> expected_res(buffer_size, identity + 1);
-
-    return test_copy(oneapi::dpl::execution::make_device_policy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue())),
-                     sycl_source.begin(), sycl_source.end(),
-                     tr_host_result_begin, sycl_result.begin(),
-                     expected_res.begin());
-  }
-};
-
-struct test_multi_transform_copy {
-  int operator()(size_t buffer_size) {
-
-    int identity = 0;
-    std::vector<int> source(buffer_size, identity);
-    std::vector<int> res(buffer_size, identity);
-
-    dpct::device_vector<int> sycl_source(source.begin(), source.end());
-    dpct::device_vector<int> sycl_result(res.begin(), res.end());
-
-    auto transformation1 = [](int item) { return item + 1; };
-    auto transformation2 = [](int item) { return item * 2; };
-    auto transformation3 = [](int item) { return item + 3; };
-
-    auto tr_sycl_result_begin = dpct::make_transform_output_iterator(
-        sycl_result.begin(), transformation1);
-    auto tr2_sycl_result_begin = dpct::make_transform_output_iterator(
-        tr_sycl_result_begin, transformation2);
-    auto tr3_sycl_result_begin = dpct::make_transform_output_iterator(
-        tr2_sycl_result_begin, transformation3);
-
-    ::std::vector<int> expected_res(buffer_size, ((identity + 3) * 2) + 1);
-
-    return test_copy(oneapi::dpl::execution::make_device_policy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue())),
-                     sycl_source.begin(), sycl_source.end(),
-                     tr3_sycl_result_begin, sycl_result.begin(),
-                     expected_res.begin());
-  }
-};
-
-struct test_fill_transform {
-  int operator()(size_t buffer_size) {
-
-    int identity = 0;
-    std::vector<int> res(buffer_size, identity);
-
-    dpct::device_vector<int> sycl_result(res.begin(), res.end());
-
-    auto transformation = [](int item) { return item + 1; };
-
-    {
-      auto tr_source_begin = dpct::make_transform_output_iterator(
-          sycl_result.begin(), transformation);
-      ::std::fill_n(tr_source_begin, buffer_size, identity);
-    }
-
-    ::std::vector<int> expected_res(buffer_size, identity + 1);
-
-    return ASSERT_EQUAL_N(
-        expected_res.begin(), sycl_result.begin(), buffer_size,
-        "Wrong result from fill with transform_output_iterator");
-  }
-};
-
-struct test_type_shift {
-  int operator()(size_t buffer_size) {
-
-    double init = 0.5;
-    std::vector<double> source(buffer_size, init);
-    std::vector<int> res(buffer_size, 0);
-
-    dpct::device_vector<double> sycl_source(source.begin(), source.end());
-    dpct::device_vector<int> sycl_result(res.begin(), res.end());
-
-    // 3. run algorithms
-    auto transformation1 = [](float item) { return (int)(item * 2.0f); };
-    auto transformation2 = [](double item) { return (float)(item + 1.0); };
-
-    auto tr1_host_result_begin = dpct::make_transform_output_iterator(
-        sycl_result.begin(), transformation1);
-    auto tr2_host_result_begin = dpct::make_transform_output_iterator(
-        tr1_host_result_begin, transformation2);
-
-    ::std::vector<int> expected_res(buffer_size,
-                                    (int)((float)(init + 1.0) * 2.0f));
-
-    return test_copy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-                     sycl_source.begin(), sycl_source.end(),
-                     tr2_host_result_begin, sycl_result.begin(),
-                     expected_res.begin());
-  }
-};
-
-struct test_zip_iterator {
-  int operator()(size_t buffer_size) {
-
-    float init = 2.0f;
-    std::vector<int> source(buffer_size, init);
-    std::vector<int> res1(buffer_size, 0.0f);
-    std::vector<int> res2(buffer_size, 0.0f);
-
-    dpct::device_vector<float> sycl_source(source.begin(), source.end());
-    dpct::device_vector<float> sycl_result1(res1.begin(), res1.end());
-    dpct::device_vector<float> sycl_result2(res2.begin(), res2.end());
-
-    auto zip =
-        oneapi::dpl::make_zip_iterator(sycl_result1.begin(), sycl_result2.begin());
-
-    auto transformation1 = [](const auto &item) {
-      return ::std::make_tuple(item - 1.0f, item * item);
-    };
-    auto tr1_host_result_begin =
-        dpct::make_transform_output_iterator(zip, transformation1);
-
-    ::std::vector<float> expected_res1(buffer_size, init - 1.0f);
-    ::std::vector<float> expected_res2(buffer_size, init * init);
-    auto zip_res = oneapi::dpl::make_zip_iterator(expected_res1.begin(),
-                                                  expected_res2.begin());
-
-    ::std::copy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-                sycl_source.begin(), sycl_source.end(),
-                tr1_host_result_begin);
-
+int
+ASSERT_EQUAL_N(_T1&& X, _T2&& Y, ::std::size_t n, String msg)
+{
     int failed_tests = 0;
-    failed_tests +=
-        ASSERT_EQUAL_N(expected_res1.begin(), sycl_result1.begin(), buffer_size,
-                       "Wrong result from copy with transform_output_iterator");
-    failed_tests +=
-        ASSERT_EQUAL_N(expected_res2.begin(), sycl_result2.begin(), buffer_size,
-                       "Wrong result from copy with transform_output_iterator");
-
+    for (size_t i = 0; i < n; i++)
+    {
+        failed_tests += ASSERT_EQUAL(*X, *Y, msg);
+        X++;
+        Y++;
+    }
     return failed_tests;
-  }
+}
+
+int
+test_passed(int failing_elems, std::string test_name)
+{
+    if (failing_elems == 0)
+    {
+        std::cout << "PASS: " << test_name << std::endl;
+        return 0;
+    }
+    return 1;
+}
+
+template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4>
+int
+test_copy(ExecutionPolicy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator3 result,
+          Iterator4 expected_values)
+{
+
+    ::std::copy(::std::forward<ExecutionPolicy>(exec), first1, last1, first2);
+    // result is the base iterator for the transform_output_iterator
+    // first2
+    return ASSERT_EQUAL_N(expected_values, result, last1 - first1,
+                          "Wrong result from copy with transform_output_iterator");
+}
+
+struct test_simple_copy
+{
+    int
+    operator()(size_t buffer_size)
+    {
+
+        int identity = 0;
+        std::vector<int> source(buffer_size, identity);
+        std::vector<int> res(buffer_size, identity);
+
+        dpct::device_vector<int> sycl_source(source.begin(), source.end());
+        dpct::device_vector<int> sycl_result(res.begin(), res.end());
+
+        auto transformation = [](int item) { return item + 1; };
+
+        auto tr_host_result_begin = dpct::make_transform_output_iterator(sycl_result.begin(), transformation);
+
+        ::std::vector<int> expected_res(buffer_size, identity + 1);
+
+        return test_copy(oneapi::dpl::execution::make_device_policy(
+                             oneapi::dpl::execution::make_device_policy(dpct::get_default_queue())),
+                         sycl_source.begin(), sycl_source.end(), tr_host_result_begin, sycl_result.begin(),
+                         expected_res.begin());
+    }
+};
+
+struct test_multi_transform_copy
+{
+    int
+    operator()(size_t buffer_size)
+    {
+
+        int identity = 0;
+        std::vector<int> source(buffer_size, identity);
+        std::vector<int> res(buffer_size, identity);
+
+        dpct::device_vector<int> sycl_source(source.begin(), source.end());
+        dpct::device_vector<int> sycl_result(res.begin(), res.end());
+
+        auto transformation1 = [](int item) { return item + 1; };
+        auto transformation2 = [](int item) { return item * 2; };
+        auto transformation3 = [](int item) { return item + 3; };
+
+        auto tr_sycl_result_begin = dpct::make_transform_output_iterator(sycl_result.begin(), transformation1);
+        auto tr2_sycl_result_begin = dpct::make_transform_output_iterator(tr_sycl_result_begin, transformation2);
+        auto tr3_sycl_result_begin = dpct::make_transform_output_iterator(tr2_sycl_result_begin, transformation3);
+
+        ::std::vector<int> expected_res(buffer_size, ((identity + 3) * 2) + 1);
+
+        return test_copy(oneapi::dpl::execution::make_device_policy(
+                             oneapi::dpl::execution::make_device_policy(dpct::get_default_queue())),
+                         sycl_source.begin(), sycl_source.end(), tr3_sycl_result_begin, sycl_result.begin(),
+                         expected_res.begin());
+    }
+};
+
+struct test_fill_transform
+{
+    int
+    operator()(size_t buffer_size)
+    {
+
+        int identity = 0;
+        std::vector<int> res(buffer_size, identity);
+
+        dpct::device_vector<int> sycl_result(res.begin(), res.end());
+
+        auto transformation = [](int item) { return item + 1; };
+
+        {
+            auto tr_source_begin = dpct::make_transform_output_iterator(sycl_result.begin(), transformation);
+            ::std::fill_n(tr_source_begin, buffer_size, identity);
+        }
+
+        ::std::vector<int> expected_res(buffer_size, identity + 1);
+
+        return ASSERT_EQUAL_N(expected_res.begin(), sycl_result.begin(), buffer_size,
+                              "Wrong result from fill with transform_output_iterator");
+    }
+};
+
+struct test_type_shift
+{
+    int
+    operator()(size_t buffer_size)
+    {
+
+        double init = 0.5;
+        std::vector<double> source(buffer_size, init);
+        std::vector<int> res(buffer_size, 0);
+
+        dpct::device_vector<double> sycl_source(source.begin(), source.end());
+        dpct::device_vector<int> sycl_result(res.begin(), res.end());
+
+        // 3. run algorithms
+        auto transformation1 = [](float item) { return (int)(item * 2.0f); };
+        auto transformation2 = [](double item) { return (float)(item + 1.0); };
+
+        auto tr1_host_result_begin = dpct::make_transform_output_iterator(sycl_result.begin(), transformation1);
+        auto tr2_host_result_begin = dpct::make_transform_output_iterator(tr1_host_result_begin, transformation2);
+
+        ::std::vector<int> expected_res(buffer_size, (int)((float)(init + 1.0) * 2.0f));
+
+        return test_copy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), sycl_source.begin(),
+                         sycl_source.end(), tr2_host_result_begin, sycl_result.begin(), expected_res.begin());
+    }
+};
+
+struct test_zip_iterator
+{
+    int
+    operator()(size_t buffer_size)
+    {
+
+        float init = 2.0f;
+        std::vector<int> source(buffer_size, init);
+        std::vector<int> res1(buffer_size, 0.0f);
+        std::vector<int> res2(buffer_size, 0.0f);
+
+        dpct::device_vector<float> sycl_source(source.begin(), source.end());
+        dpct::device_vector<float> sycl_result1(res1.begin(), res1.end());
+        dpct::device_vector<float> sycl_result2(res2.begin(), res2.end());
+
+        auto zip = oneapi::dpl::make_zip_iterator(sycl_result1.begin(), sycl_result2.begin());
+
+        auto transformation1 = [](const auto& item) { return ::std::make_tuple(item - 1.0f, item * item); };
+        auto tr1_host_result_begin = dpct::make_transform_output_iterator(zip, transformation1);
+
+        ::std::vector<float> expected_res1(buffer_size, init - 1.0f);
+        ::std::vector<float> expected_res2(buffer_size, init * init);
+        auto zip_res = oneapi::dpl::make_zip_iterator(expected_res1.begin(), expected_res2.begin());
+
+        ::std::copy(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), sycl_source.begin(),
+                    sycl_source.end(), tr1_host_result_begin);
+
+        int failed_tests = 0;
+        failed_tests += ASSERT_EQUAL_N(expected_res1.begin(), sycl_result1.begin(), buffer_size,
+                                       "Wrong result from copy with transform_output_iterator");
+        failed_tests += ASSERT_EQUAL_N(expected_res2.begin(), sycl_result2.begin(), buffer_size,
+                                       "Wrong result from copy with transform_output_iterator");
+
+        return failed_tests;
+    }
 };
 
 template <typename OutputIterator1, typename UnaryFunc>
-auto attempt_to_dangle(OutputIterator1 out1, UnaryFunc unary) {
-  auto toi = dpct::make_transform_output_iterator(out1, unary);
-  // Leave scope of the transform output iterator, then assign data
-  // to the wrapper after the fact.
-  return *toi;
+auto
+attempt_to_dangle(OutputIterator1 out1, UnaryFunc unary)
+{
+    auto toi = dpct::make_transform_output_iterator(out1, unary);
+    // Leave scope of the transform output iterator, then assign data
+    // to the wrapper after the fact.
+    return *toi;
 }
 
-template <typename ExecutionPolicy, typename InputIterator,
-          typename OutputIterator, typename Iterator3,
+template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator, typename Iterator3,
           typename UnaryFunc>
-int dangle_test(ExecutionPolicy &&exec, InputIterator first, InputIterator last,
-                OutputIterator output_first, Iterator3 expected_values, 
-                UnaryFunc unary) {
-  auto num_eles = last - first;
-  oneapi::dpl::counting_iterator<::std::size_t> count_first(0UL);
-  oneapi::dpl::counting_iterator<::std::size_t> count_last(num_eles);
-  std::for_each(::std::forward<ExecutionPolicy>(exec), count_first, count_last,
-                [=](const auto &elem) {
-                  auto wrapper = attempt_to_dangle(output_first + elem, unary);
-                  // Assigning to wrapper object after transform iterator
-                  //   leaves scope, still should perform transformation
-                  wrapper = first[elem];
-                });
+int
+dangle_test(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator output_first,
+            Iterator3 expected_values, UnaryFunc unary)
+{
+    auto num_eles = last - first;
+    oneapi::dpl::counting_iterator<::std::size_t> count_first(0UL);
+    oneapi::dpl::counting_iterator<::std::size_t> count_last(num_eles);
+    std::for_each(::std::forward<ExecutionPolicy>(exec), count_first, count_last, [=](const auto& elem) {
+        auto wrapper = attempt_to_dangle(output_first + elem, unary);
+        // Assigning to wrapper object after transform iterator
+        //   leaves scope, still should perform transformation
+        wrapper = first[elem];
+    });
 
-  return ASSERT_EQUAL_N(
-      expected_values, output_first, num_eles,
-      "Wrong result from usage of transform_output_iterator (dangle_test) ");
+    return ASSERT_EQUAL_N(expected_values, output_first, num_eles,
+                          "Wrong result from usage of transform_output_iterator (dangle_test) ");
 }
 
-struct test_dangling_ref {
-  int operator()(size_t buffer_size) {
+struct test_dangling_ref
+{
+    int
+    operator()(size_t buffer_size)
+    {
 
-    float init = 2.0f;
-    std::vector<float> source(buffer_size, init);
-    std::vector<float> res(buffer_size, 0.0f);
+        float init = 2.0f;
+        std::vector<float> source(buffer_size, init);
+        std::vector<float> res(buffer_size, 0.0f);
 
-    dpct::device_vector<float> sycl_source(source.begin(), source.end());
-    dpct::device_vector<float> sycl_result(res.begin(), res.end());
+        dpct::device_vector<float> sycl_source(source.begin(), source.end());
+        dpct::device_vector<float> sycl_result(res.begin(), res.end());
 
-    ::std::vector<float> expected_res(buffer_size, init * init);
+        ::std::vector<float> expected_res(buffer_size, init * init);
 
-    auto transformation1 = [](const auto &item) { return item * item; };
+        auto transformation1 = [](const auto& item) { return item * item; };
 
-    return dangle_test(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
-                       sycl_source.begin(), sycl_source.end(),
-                       sycl_result.begin(), expected_res.begin(),
-                       transformation1);
-  }
+        return dangle_test(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), sycl_source.begin(),
+                           sycl_source.end(), sycl_result.begin(), expected_res.begin(), transformation1);
+    }
 };
 
 template <typename OutputIterator1, typename UnaryFunc1, typename UnaryFunc2>
-auto attempt_to_dangle_chain(OutputIterator1 out1, UnaryFunc1 unary1,
-                             UnaryFunc2 unary2) {
-  auto toi1 = dpct::make_transform_output_iterator(out1, unary1);
-  auto toi2 = dpct::make_transform_output_iterator(toi1, unary2);
-  // leave scope of the transform output iterator, then assign
-  // data to the wrapper after the fact.
-  return *toi2;
+auto
+attempt_to_dangle_chain(OutputIterator1 out1, UnaryFunc1 unary1, UnaryFunc2 unary2)
+{
+    auto toi1 = dpct::make_transform_output_iterator(out1, unary1);
+    auto toi2 = dpct::make_transform_output_iterator(toi1, unary2);
+    // leave scope of the transform output iterator, then assign
+    // data to the wrapper after the fact.
+    return *toi2;
 }
 
 template <typename ExecutionPolicy, typename InputIterator, typename OutputIterator, typename Iterator3,
           typename UnaryFunc1, typename UnaryFunc2>
-int chain_dangle_test(ExecutionPolicy &&exec, InputIterator first,
-                      InputIterator last, OutputIterator output_first,
-                      Iterator3 expected_values, UnaryFunc1 unary1,
-                      UnaryFunc2 unary2) {
-  auto num_eles = last - first;
-  oneapi::dpl::counting_iterator<::std::size_t> count_first(0UL);
-  oneapi::dpl::counting_iterator<::std::size_t> count_last(num_eles);
-  std::for_each(::std::forward<ExecutionPolicy>(exec), count_first, count_last,
-                [=](const auto &elem) {
-                  auto wrapper =
-                      attempt_to_dangle_chain(output_first + elem, unary1, unary2);
-                  // assigning to wrapper object after transform iterator
-                  // leaves scope
-                  wrapper = first[elem];
-                });
+int
+chain_dangle_test(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator output_first,
+                  Iterator3 expected_values, UnaryFunc1 unary1, UnaryFunc2 unary2)
+{
+    auto num_eles = last - first;
+    oneapi::dpl::counting_iterator<::std::size_t> count_first(0UL);
+    oneapi::dpl::counting_iterator<::std::size_t> count_last(num_eles);
+    std::for_each(::std::forward<ExecutionPolicy>(exec), count_first, count_last, [=](const auto& elem) {
+        auto wrapper = attempt_to_dangle_chain(output_first + elem, unary1, unary2);
+        // assigning to wrapper object after transform iterator
+        // leaves scope
+        wrapper = first[elem];
+    });
 
-  return ASSERT_EQUAL_N(expected_values, output_first, num_eles,
-                        "Wrong result from usage of transform_output_iterator "
-                        "(chain_dangle_test) ");
+    return ASSERT_EQUAL_N(expected_values, output_first, num_eles,
+                          "Wrong result from usage of transform_output_iterator "
+                          "(chain_dangle_test) ");
 }
 
-struct test_dangling_chain_ref {
-  int operator()(size_t buffer_size) {
+struct test_dangling_chain_ref
+{
+    int
+    operator()(size_t buffer_size)
+    {
 
-    float init = 2.0f;
-    std::vector<float> source(buffer_size, init);
-    std::vector<float> res(buffer_size, 0.0f);
+        float init = 2.0f;
+        std::vector<float> source(buffer_size, init);
+        std::vector<float> res(buffer_size, 0.0f);
 
-    dpct::device_vector<float> sycl_source(source.begin(), source.end());
-    dpct::device_vector<float> sycl_result(res.begin(), res.end());
+        dpct::device_vector<float> sycl_source(source.begin(), source.end());
+        dpct::device_vector<float> sycl_result(res.begin(), res.end());
 
-    ::std::vector<float> expected_res(buffer_size, (init * init) - 2.0f);
+        ::std::vector<float> expected_res(buffer_size, (init * init) - 2.0f);
 
-    auto transformation1 = [](const auto &item) { return item - 2.0f; };
-    auto transformation2 = [](const auto &item) { return item * item; };
+        auto transformation1 = [](const auto& item) { return item - 2.0f; };
+        auto transformation2 = [](const auto& item) { return item * item; };
 
-    return chain_dangle_test(
-        oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()), sycl_source.begin(),
-        sycl_source.end(), sycl_result.begin(), expected_res.begin(), transformation1, transformation2);
-  }
+        return chain_dangle_test(oneapi::dpl::execution::make_device_policy(dpct::get_default_queue()),
+                                 sycl_source.begin(), sycl_source.end(), sycl_result.begin(), expected_res.begin(),
+                                 transformation1, transformation2);
+    }
 };
 
-
 template <typename TestFunctor>
-int RunTest(TestFunctor test, size_t max_n, ::std::string msg) {
-  int failed_tests = 0;
-  for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n)) {
-    failed_tests += test(n);
-  }
-  return test_passed(failed_tests, msg);
+int
+RunTest(TestFunctor test, size_t max_n, ::std::string msg)
+{
+    int failed_tests = 0;
+    for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    {
+        failed_tests += test(n);
+    }
+    return test_passed(failed_tests, msg);
 }
 
-int main() {
+int
+main()
+{
 
-  // used to detect failures
+    // used to detect failures
 
-  int test_suites_failed = 0;
-  size_t max_n = 10000;
+    int test_suites_failed = 0;
+    size_t max_n = 10000;
 
-  test_suites_failed += RunTest(test_simple_copy(), max_n, "Simple Copy");
-  test_suites_failed +=
-      RunTest(test_multi_transform_copy(), max_n, "Multiple Transforms");
-  test_suites_failed +=
-      RunTest(test_fill_transform(), max_n, "Simple Host Fill");
-  test_suites_failed +=
-      RunTest(test_type_shift(), max_n, "Type Shifting Transform");
-  test_suites_failed +=
-      RunTest(test_zip_iterator(), max_n, "Zip Iterator Transform");
-  test_suites_failed +=
-      RunTest(test_dangling_ref(), max_n, "Checking Reference Not Dangled");
-  test_suites_failed += RunTest(test_dangling_chain_ref(), max_n,
-                                "Checking Reference Not Dangled Chain");
+    test_suites_failed += RunTest(test_simple_copy(), max_n, "Simple Copy");
+    test_suites_failed += RunTest(test_multi_transform_copy(), max_n, "Multiple Transforms");
+    test_suites_failed += RunTest(test_fill_transform(), max_n, "Simple Host Fill");
+    test_suites_failed += RunTest(test_type_shift(), max_n, "Type Shifting Transform");
+    test_suites_failed += RunTest(test_zip_iterator(), max_n, "Zip Iterator Transform");
+    test_suites_failed += RunTest(test_dangling_ref(), max_n, "Checking Reference Not Dangled");
+    test_suites_failed += RunTest(test_dangling_chain_ref(), max_n, "Checking Reference Not Dangled Chain");
 
-  std::cout << std::endl
-            << test_suites_failed << " failing test(s) detected." << std::endl;
-  if (test_suites_failed == 0) {
-    return 0;
-  }
-  return 1;
+    std::cout << std::endl << test_suites_failed << " failing test(s) detected." << std::endl;
+    if (test_suites_failed == 0)
+    {
+        return 0;
+    }
+    return 1;
 }


### PR DESCRIPTION
Adding tests for dpct::make_transform_output_iterator.  

Meant to test code added in https://github.com/oneapi-src/SYCLomatic/pull/361.  Tests will not pass until this PR is merged.