### PR TITLE
[SYCLomatic #481] Enable test for dpct::device_vector move semantics

### DIFF
--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -5,6 +5,7 @@
   <tests>
     <test testName="array_copy" configFile="config/TEMPLATE_help_function.xml" />
     <test testName="assign_device_vector" configFile="config/TEMPLATE_help_function.xml" />
+    <test testName="move_device_vector" configFile="config/TEMPLATE_help_function.xml" />
     <test testName="atomic_add_float" configFile="config/TEMPLATE_help_function.xml" />
     <test testName="atomic_fetch_compare_inc" configFile="config/TEMPLATE_help_function.xml" />
     <test testName="async_exception" configFile="config/TEMPLATE_help_function.xml" />

--- a/help_function/src/move_device_vector.cpp
+++ b/help_function/src/move_device_vector.cpp
@@ -1,0 +1,31 @@
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/algorithm>
+#include <sycl.hpp>
+#include <dpct/dpct.hpp>
+#include <dpct/dpl_utils.hpp>
+
+bool verify(dpct::device_vector<int> &D, int N, int V) {
+  if (D.size() != N)
+    return false;
+  for (int i = 0; i < N; ++i)
+    if (D[i] != V)
+      return false;
+  return true;
+}
+
+int main(void) {
+  constexpr int N = 4;
+  constexpr int V = 42;
+  // Construct D1 from move constructor.
+  dpct::device_vector<int> D1(std::move(dpct::device_vector<int>(N, V)));
+  if (!verify(D1, N, V)) {
+    return 1;
+  }
+  // Move assign to D2.
+  dpct::device_vector<int> D2;
+  D2 = std::move(dpct::device_vector<int>(N, V));
+  if (!verify(D2, N, V)) {
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
Signed-off-by: Yilong Guo <yilong.guo@intel.com>