### PR TITLE
[SYCLomatic #510] Avoid multiple func def if DNN header is included in multiple files

### DIFF
--- a/features/config/TEMPLATE_cudnn_multiple_files.xml
+++ b/features/config/TEMPLATE_cudnn_multiple_files.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test driverID="test_feature" name="TEMPLATE">
+   <description>test</description>
+    <files>
+      <file path="feature_case/dnn/cudnn-scale.cu" />
+      <file path="feature_case/dnn/cudnn-sum.cu" />      
+      <file path="feature_case/cudnn_multiple_files" />
+    </files>
+    <rules />
+</test>

--- a/features/feature_case/cudnn_multiple_files/do_test.py
+++ b/features/feature_case/cudnn_multiple_files/do_test.py
@@ -1,0 +1,45 @@
+# ====------ do_test.py---------- *- Python -* ----===##
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#
+# ===----------------------------------------------------------------------===#
+import subprocess
+import platform
+import os
+import sys
+from test_config import CT_TOOL
+
+from test_utils import *
+
+def setup_test():
+    change_dir(test_config.current_test)
+    return True
+
+def migrate_test():
+    # clean previous migration output
+    if (os.path.exists("dpct_output")):
+        shutil.rmtree("dpct_output")
+
+    call_subprocess("sed 's/main/scale_main/' cudnn-scale.cu --in-place")
+    call_subprocess("sed 's/main/sum_main/'   cudnn-sum.cu   --in-place")    
+    call_subprocess(test_config.CT_TOOL + " --cuda-include-path=" + test_config.include_path + " multiple_main.cpp cudnn-scale.cu cudnn-sum.cu")
+    return os.path.exists(os.path.join("dpct_output", "cudnn-scale.dp.cpp"))
+
+def build_test():
+    srcs = []
+    objects = []
+    if platform.system() == 'Linux':    
+        linkopt = ["-ldnnl"]
+    else:
+        linkopt = ["dnnl.lib"]
+        
+    srcs.append(os.path.join("dpct_output", "multiple_main.cpp"))
+    srcs.append(os.path.join("dpct_output", "cudnn-scale.dp.cpp"))
+    srcs.append(os.path.join("dpct_output", "cudnn-sum.dp.cpp"))
+    return compile_and_link(srcs,objects,linkopt)
+
+def run_test():
+    return call_subprocess(os.path.join(os.path.curdir, test_config.current_test + '.run '))

--- a/features/feature_case/cudnn_multiple_files/multiple_main.cpp
+++ b/features/feature_case/cudnn_multiple_files/multiple_main.cpp
@@ -1,0 +1,9 @@
+int scale_main();
+int sum_main();
+
+int main() {
+  if (scale_main()) return 1;
+  if (sum_main())   return 1;
+
+  return 0;
+}

--- a/features/features.xml
+++ b/features/features.xml
@@ -132,6 +132,7 @@
     <test testName="cub_transform_iterator" configFile="config/TEMPLATE_cub_transform_iterator.xml" />
     <test testName="cub_constant_iterator" configFile="config/TEMPLATE_cub_device.xml" />
     <test testName="cub_arg_index_input_iterator" configFile="config/TEMPLATE_cub_device.xml" />
+    <test testName="cudnn_multiple_files" configFile="config/TEMPLATE_cudnn_multiple_files.xml" />
     <test testName="cudnn-activation" configFile="config/TEMPLATE_cuDNN.xml" />
     <test testName="cudnn-fill" configFile="config/TEMPLATE_cuDNN.xml" />
     <test testName="cudnn-lrn" configFile="config/TEMPLATE_cuDNN.xml" />

--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -33,6 +33,7 @@ exec_tests = ['thrust-vector-2', 'thrust-binary-search', 'thrust-count', 'thrust
               'cudnn-sum', 'math-funnelshift', 'ccl', 'thrust-sort_by_key', 'thrust-find', 'thrust-inner_product', 'thrust-reduce_by_key',
               'math-bfloat16', 'libcu_atomic', 'test_shared_memory', 'cudnn-reduction', 'cudnn-binary', 'cudnn-bnp1', 'cudnn-bnp2', 'cudnn-bnp3',
               'cudnn-normp1', 'cudnn-normp2', 'cudnn-normp3', 'cudnn-convp1', 'cudnn-convp2', 'cudnn-convp3', 'cudnn-convp4', 'cudnn-convp5',
+              'cudnn_mutilple_files'
               'thrust-unique_by_key', 'cufft_test', 'cufft-external-workspace', "pointer_attributes", 'math_intel_specific', 'math-drcp', 'thrust-pinned-allocator', 'driverMem',
               'cusolver_test1', 'cusolver_test2', 'thrust_op', 'cublas-extension', 'cublas_v1_runable', 'thrust_minmax_element',
               'thrust_is_sorted', 'thrust_partition', 'thrust_remove_copy', 'thrust_unique_copy', 'thrust_transform_exclusive_scan',


### PR DESCRIPTION
Add inline to functions in dnnl_utils.hpp to avoid multiple function definition if header is included in multiple files.

Signed-off-by: Lu, John <john.lu@intel.com>