### PR TITLE
[SYCLomatic #493] Add test for DeviceRadixSort cub::DoubleBuffer APIs

### DIFF
--- a/features/feature_case/cub/cub_device_radix_sort_keys.cu
+++ b/features/feature_case/cub/cub_device_radix_sort_keys.cu
@@ -12,25 +12,40 @@ template <typename T> T *init(std::initializer_list<T> list) {
   return arr;
 }
 
-bool test() {
+bool test(bool useDoubleBuffer=false) {
   int num_items = 7;
   int *d_keys_in = init({8, 6, 7, 5, 3, 0, 9});
   int *d_keys_out = init({0, 0, 0, 0, 0, 0, 0});
   std::vector<int> expected_keys_out{0, 3, 5, 6, 7, 8, 9};
+  cub::DoubleBuffer<int> buffers(d_keys_in, d_keys_out);
 
-  // Determine temporary device storage requirements
   void *d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
-                                 d_keys_out, num_items);
+  auto doSort = [&]() {
+    if (useDoubleBuffer) {
+      cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, buffers,
+                                     num_items);
+    } else {
+      cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
+                                     d_keys_out, num_items);
+    }
+  };
+
+  // Determine temporary device storage requirements
+  doSort();
   // Allocate temporary storage
   cudaMalloc(&d_temp_storage, temp_storage_bytes);
   // Run sorting operation
-  cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
-                                 d_keys_out, num_items);
+  doSort();
+  
   std::vector<int> keys_out(num_items);
-  cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
-             cudaMemcpyDeviceToHost);
+  if (useDoubleBuffer) {
+    cudaMemcpy(keys_out.data(), buffers.Current(), sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  } else {
+    cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  }
   cudaFree(d_keys_in);
   cudaFree(d_keys_out);
   cudaFree(d_temp_storage);
@@ -38,25 +53,40 @@ bool test() {
                     keys_out.begin());
 }
 
-bool test1() {
+bool test1(bool useDoubleBuffer=false) {
   int num_items = 7;
   int *d_keys_in = init({8, 6, 7, 5, 3, 0, 9});
   int *d_keys_out = init({0, 0, 0, 0, 0, 0, 0});
   std::vector<int> expected_keys_out{3, 0, 6, 7, 5, 8, 9};
+  cub::DoubleBuffer<int> buffers(d_keys_in, d_keys_out);
 
-  // Determine temporary device storage requirements
   void *d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
-                                 d_keys_out, num_items, 2);
+  auto doSort = [&]() {
+    if (useDoubleBuffer) {
+      cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, buffers,
+                                     num_items, 2);
+    } else {
+      cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
+                                     d_keys_out, num_items, 2);
+    }
+  };
+
+  // Determine temporary device storage requirements
+  doSort();
   // Allocate temporary storage
   cudaMalloc(&d_temp_storage, temp_storage_bytes);
   // Run sorting operation
-  cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
-                                 d_keys_out, num_items, 2);
+  doSort();
+  
   std::vector<int> keys_out(num_items);
-  cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
-             cudaMemcpyDeviceToHost);
+  if (useDoubleBuffer) {
+    cudaMemcpy(keys_out.data(), buffers.Current(), sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  } else {
+    cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  }
   cudaFree(d_keys_in);
   cudaFree(d_keys_out);
   cudaFree(d_temp_storage);
@@ -65,25 +95,42 @@ bool test1() {
                     keys_out.begin());
 }
 
-bool test2() {
+bool test2(bool useDoubleBuffer=false) {
   int num_items = 7;
   int *d_keys_in = init({8, 6, 7, 5, 3, 0, 9});
   int *d_keys_out = init({0, 0, 0, 0, 0, 0, 0});
   std::vector<int> expected_keys_out{3, 0, 6, 7, 5, 8, 9};
+  cub::DoubleBuffer<int> buffers(d_keys_in, d_keys_out);
 
-  // Determine temporary device storage requirements
   void *d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
-                                 d_keys_out, num_items, 2, 4);
+  auto doSort = [&]() {
+    if (useDoubleBuffer) {
+      cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, buffers,
+                                     num_items, 2, 4);
+    } else {
+      cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
+                                     d_keys_out, num_items, 2, 4);
+    }
+  };
+  
+  // Determine temporary device storage requirements
+  doSort();
   // Allocate temporary storage
   cudaMalloc(&d_temp_storage, temp_storage_bytes);
   // Run sorting operation
-  cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
-                                 d_keys_out, num_items, 2, 4);
+  doSort();
+  
   std::vector<int> keys_out(num_items);
   cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
              cudaMemcpyDeviceToHost);
+  if (useDoubleBuffer) {
+    cudaMemcpy(keys_out.data(), buffers.Current(), sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  } else {
+    cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  }
   cudaFree(d_keys_in);
   cudaFree(d_keys_out);
   cudaFree(d_temp_storage);
@@ -92,27 +139,41 @@ bool test2() {
                     keys_out.begin());
 }
 
-bool test3() {
+bool test3(bool useDoubleBuffer=false) {
   int num_items = 7;
   int *d_keys_in = init({8, 6, 7, 5, 3, 0, 9});
   int *d_keys_out = init({0, 0, 0, 0, 0, 0, 0});
   std::vector<int> expected_keys_out{3, 0, 6, 7, 5, 8, 9};
+  cub::DoubleBuffer<int> buffers(d_keys_in, d_keys_out);
   cudaStream_t s = nullptr;
   cudaStreamCreate(&s);
 
-  // Determine temporary device storage requirements
   void *d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
-                                 d_keys_out, num_items, 2, 4, s);
+  auto doSort = [&]() {
+    if (useDoubleBuffer) {
+      cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, buffers,
+                                     num_items, 2, 4, s);
+    } else {
+      cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
+                                     d_keys_out, num_items, 2, 4, s);
+    }
+  };
+  // Determine temporary device storage requirements
+  doSort();
   // Allocate temporary storage
   cudaMalloc(&d_temp_storage, temp_storage_bytes);
   // Run sorting operation
-  cub::DeviceRadixSort::SortKeys(d_temp_storage, temp_storage_bytes, d_keys_in,
-                                 d_keys_out, num_items, 2, 4, s);
+  doSort();
+
   std::vector<int> keys_out(num_items);
-  cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
-             cudaMemcpyDeviceToHost);
+  if (useDoubleBuffer) {
+    cudaMemcpy(keys_out.data(), buffers.Current(), sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  } else {
+    cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  }
   cudaFree(d_keys_in);
   cudaFree(d_keys_out);
   cudaFree(d_temp_storage);
@@ -122,25 +183,40 @@ bool test3() {
                     keys_out.begin());
 }
 
-bool test_descending() {
+bool test_descending(bool useDoubleBuffer=false) {
   int num_items = 7;
   int *d_keys_in = init({8, 6, 7, 5, 3, 0, 9});
   int *d_keys_out = init({0, 0, 0, 0, 0, 0, 0});
   std::vector<int> expected_keys_out{9, 8, 7, 6, 5, 3, 0};
+  cub::DoubleBuffer<int> buffers(d_keys_in, d_keys_out);
 
-  // Determine temporary device storage requirements
   void *d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
-                                           d_keys_in, d_keys_out, num_items);
+  auto doSort = [&]() {
+    if (useDoubleBuffer) {
+      cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
+                                               buffers, num_items);
+    } else {
+      cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
+                                               d_keys_in, d_keys_out, num_items);
+    }
+  };
+
+  // Determine temporary device storage requirements
+  doSort();
   // Allocate temporary storage
   cudaMalloc(&d_temp_storage, temp_storage_bytes);
   // Run sorting operation
-  cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
-                                           d_keys_in, d_keys_out, num_items);
+  doSort();
+
   std::vector<int> keys_out(num_items);
-  cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
-             cudaMemcpyDeviceToHost);
+  if (useDoubleBuffer) {
+    cudaMemcpy(keys_out.data(), buffers.Current(), sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  } else {
+    cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  }
   cudaFree(d_keys_in);
   cudaFree(d_keys_out);
   cudaFree(d_temp_storage);
@@ -148,25 +224,39 @@ bool test_descending() {
                     keys_out.begin());
 }
 
-bool test_descending1() {
+bool test_descending1(bool useDoubleBuffer=false) {
   int num_items = 7;
   int *d_keys_in = init({8, 6, 7, 5, 3, 0, 9});
   int *d_keys_out = init({0, 0, 0, 0, 0, 0, 0});
   std::vector<int> expected_keys_out{8, 9, 6, 7, 5, 3, 0};
+  cub::DoubleBuffer<int> buffers(d_keys_in, d_keys_out);
 
-  // Determine temporary device storage requirements
   void *d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
-                                           d_keys_in, d_keys_out, num_items, 2);
+  auto doSort = [&]() {
+    if (useDoubleBuffer) {
+      cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
+                                               buffers, num_items, 2);
+    } else {
+      cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
+                                               d_keys_in, d_keys_out, num_items, 2);
+    }
+  };
+  // Determine temporary device storage requirements
+  doSort();
   // Allocate temporary storage
   cudaMalloc(&d_temp_storage, temp_storage_bytes);
   // Run sorting operation
-  cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
-                                           d_keys_in, d_keys_out, num_items, 2);
+  doSort();
+
   std::vector<int> keys_out(num_items);
-  cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
-             cudaMemcpyDeviceToHost);
+  if (useDoubleBuffer) {
+    cudaMemcpy(keys_out.data(), buffers.Current(), sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  } else {
+    cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  }
   cudaFree(d_keys_in);
   cudaFree(d_keys_out);
   cudaFree(d_temp_storage);
@@ -175,25 +265,40 @@ bool test_descending1() {
                     keys_out.begin());
 }
 
-bool test_descending2() {
+bool test_descending2(bool useDoubleBuffer=false) {
   int num_items = 7;
   int *d_keys_in = init({8, 6, 7, 5, 3, 0, 9});
   int *d_keys_out = init({0, 0, 0, 0, 0, 0, 0});
   std::vector<int> expected_keys_out{8, 9, 6, 7, 5, 3, 0};
+  cub::DoubleBuffer<int> buffers(d_keys_in, d_keys_out);
 
-  // Determine temporary device storage requirements
   void *d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
-                                           d_keys_in, d_keys_out, num_items, 2, 4);
+  auto doSort = [&]() {
+    if (useDoubleBuffer) {
+      cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
+                                               buffers, num_items, 2, 4);
+    } else {
+      cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
+                                               d_keys_in, d_keys_out, num_items, 2, 4);
+    }
+  };
+
+  // Determine temporary device storage requirements
+  doSort();
   // Allocate temporary storage
   cudaMalloc(&d_temp_storage, temp_storage_bytes);
   // Run sorting operation
-  cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
-                                           d_keys_in, d_keys_out, num_items, 2, 4);
+  doSort();
+
   std::vector<int> keys_out(num_items);
-  cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
-             cudaMemcpyDeviceToHost);
+  if (useDoubleBuffer) {
+    cudaMemcpy(keys_out.data(), buffers.Current(), sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  } else {
+    cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  }
   cudaFree(d_keys_in);
   cudaFree(d_keys_out);
   cudaFree(d_temp_storage);
@@ -202,27 +307,41 @@ bool test_descending2() {
                     keys_out.begin());
 }
 
-bool test_descending3() {
+bool test_descending3(bool useDoubleBuffer=false) {
   int num_items = 7;
   int *d_keys_in = init({8, 6, 7, 5, 3, 0, 9});
   int *d_keys_out = init({0, 0, 0, 0, 0, 0, 0});
   std::vector<int> expected_keys_out{8, 9, 6, 7, 5, 3, 0};
   cudaStream_t s = nullptr;
   cudaStreamCreate(&s);
+  cub::DoubleBuffer<int> buffers(d_keys_in, d_keys_out);
 
-  // Determine temporary device storage requirements
   void *d_temp_storage = NULL;
   size_t temp_storage_bytes = 0;
-  cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
-                                           d_keys_in, d_keys_out, num_items, 2, 4, s);
+  auto doSort = [&]() {
+    if (useDoubleBuffer) {
+      cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
+                                               buffers, num_items, 2, 4, s);
+    } else {
+      cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
+                                               d_keys_in, d_keys_out, num_items, 2, 4, s);
+    }
+  };
+  // Determine temporary device storage requirements
+  doSort();
   // Allocate temporary storage
   cudaMalloc(&d_temp_storage, temp_storage_bytes);
   // Run sorting operation
-  cub::DeviceRadixSort::SortKeysDescending(d_temp_storage, temp_storage_bytes,
-                                           d_keys_in, d_keys_out, num_items, 2, 4, s);
+  doSort();
+
   std::vector<int> keys_out(num_items);
-  cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
-             cudaMemcpyDeviceToHost);
+  if (useDoubleBuffer) {
+    cudaMemcpy(keys_out.data(), buffers.Current(), sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  } else {
+    cudaMemcpy(keys_out.data(), d_keys_out, sizeof(int) * num_items,
+               cudaMemcpyDeviceToHost);
+  }
   cudaFree(d_keys_in);
   cudaFree(d_keys_out);
   cudaFree(d_temp_storage);
@@ -234,41 +353,44 @@ bool test_descending3() {
 
 int main() {
   int res = 0;
-  if (!test()) {
-    printf("cub::DeviceRadixSort::SortKeys failed\n");
-    res = 1;
-  }
-  if (!test1()) {
-    printf("cub::DeviceRadixSort::SortKeys failed\n");
-    res = 1;
-  }
-  if (!test2()) {
-    printf("cub::DeviceRadixSort::SortKeys failed\n");
-    res = 1;
-  }
-  if (!test3()) {
-    printf("cub::DeviceRadixSort::SortKeys failed\n");
-    res = 1;
-  }
+  for (auto b : {false, true}) {
+    auto s = b ? " with double buffer" : "";
+    if (!test(b)) {
+      printf("cub::DeviceRadixSort::SortKeys%s failed\n", s);
+      res = 1;
+    }
+    if (!test1(b)) {
+      printf("cub::DeviceRadixSort::SortKeys%s failed\n", s);
+      res = 1;
+    }
+    if (!test2(b)) {
+      printf("cub::DeviceRadixSort::SortKeys%s failed\n", s);
+      res = 1;
+    }
+    if (!test3(b)) {
+      printf("cub::DeviceRadixSort::SortKeys%s failed\n", s);
+      res = 1;
+    }
 
-  if (!test_descending()) {
-    printf("cub::DeviceRadixSort::SortKeysDescending failed\n");
-    res = 1;
-  }
+    if (!test_descending(b)) {
+      printf("cub::DeviceRadixSort::SortKeysDescending%s failed\n", s);
+      res = 1;
+    }
 
-  if (!test_descending1()) {
-    printf("cub::DeviceRadixSort::SortKeysDescending failed\n");
-    res = 1;
-  }
+    if (!test_descending1(b)) {
+      printf("cub::DeviceRadixSort::SortKeysDescending%s failed\n", s);
+      res = 1;
+    }
 
-  if (!test_descending2()) {
-    printf("cub::DeviceRadixSort::SortKeysDescending failed\n");
-    res = 1;
-  }
+    if (!test_descending2(b)) {
+      printf("cub::DeviceRadixSort::SortKeysDescending%s failed\n", s);
+      res = 1;
+    }
 
-  if (!test_descending3()) {
-    printf("cub::DeviceRadixSort::SortKeysDescending failed\n");
-    res = 1;
+    if (!test_descending3(b)) {
+      printf("cub::DeviceRadixSort::SortKeysDescending%s failed\n", s);
+      res = 1;
+    }
   }
 
   return res;


### PR DESCRIPTION
E2E test for: https://github.com/oneapi-src/SYCLomatic/pull/493

Signed-off-by: Cai, Justin <justin.cai@intel.com>