### PR TITLE
[SYCLomatic] fix module test

### DIFF
--- a/features/feature_case/module/module-main.cu
+++ b/features/feature_case/module/module-main.cu
@@ -28,9 +28,9 @@ int main(){
     cuLaunchKernel(F, 1, 1, 1, 1, 1, 1, 10, 0, (void**)param, nullptr);
     CUtexref tex;
     cuModuleGetTexRef(&tex, M, "tex");
-    cuModuleUnload(M);
     cudaDeviceSynchronize();
-    cudaFree(param[0]);
-    cudaFree(param[1]);
+    cuModuleUnload(M);
+    cudaFree(p0);
+    cudaFree(p1);
     return 0;
 }


### PR DESCRIPTION
Fix module test.   cudaFree was called with wrong parameters.  cudaDeviceSynchronize() must be before cuModuleUnload, otherwise unload may happen before kernel finishes.

Signed-off-by: Lu, John [john.lu@intel.com](mailto:john.lu@intel.com)