### PR TITLE
[SYCLomatic] USM_NONE testing fixes

### DIFF
--- a/help_function/config/TEMPLATE_help_function_skip_usmnone.xml
+++ b/help_function/config/TEMPLATE_help_function_skip_usmnone.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test driverID="test_help" name="TEMPLATE">
+    <description>test help function cases with usm switch on </description>
+    <files>
+        <file path="src/${testName}.cpp" />
+    </files>
+    <rules>
+        <optlevelRule excludeOptlevelNameString="usmnone" />
+        <optlevelRule excludeOptlevelNameString="cuda_backend" />
+    </rules>
+</test>

--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -151,7 +151,7 @@
     <!-- <test testName="onedpl_test_group_load" configFile="config/TEMPLATE_help_function.xml" /> -->
     <test testName="onedpl_test_transform_reduce" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />
     <test testName="onedpl_test_translate_key" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />
-    <test testName="onedpl_test_uninitialized_fill" configFile="config/TEMPLATE_help_function_usm.xml" />
+    <test testName="onedpl_test_uninitialized_fill" configFile="config/TEMPLATE_help_function_skip_usmnone.xml" />
     <test testName="onedpl_test_unique_by_key_copy" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_unique_by_key" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_unique_count" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />

--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -140,7 +140,6 @@
     <test testName="onedpl_test_stable_partition_copy" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_stable_partition" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_sys_tag_utils" configFile="config/TEMPLATE_help_function_usm.xml" />
-    <test testName="onedpl_test_transform" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_tabulate" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_tagged_pointer" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_temporary_allocation" configFile="config/TEMPLATE_help_function_usm.xml" />

--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -140,6 +140,7 @@
     <test testName="onedpl_test_stable_partition_copy" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_stable_partition" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_sys_tag_utils" configFile="config/TEMPLATE_help_function_usm.xml" />
+    <test testName="onedpl_test_transform" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_tabulate" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_tagged_pointer" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_temporary_allocation" configFile="config/TEMPLATE_help_function_usm.xml" />

--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -102,6 +102,7 @@
     <test testName="onedpl_test_count_if" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_device_new_delete" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_device_ptr" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="onedpl_test_device_malloc_free" configFile="config/TEMPLATE_help_function_skip_usmnone.xml" />
     <test testName="onedpl_test_discard_iterator" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_equal_range" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_exclusive_scan" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
@@ -149,7 +150,7 @@
     <!-- <test testName="onedpl_test_group_load" configFile="config/TEMPLATE_help_function.xml" /> -->
     <test testName="onedpl_test_transform_reduce" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />
     <test testName="onedpl_test_translate_key" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />
-    <test testName="onedpl_test_uninitialized_fill" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="onedpl_test_uninitialized_fill" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_unique_by_key_copy" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_unique_by_key" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_unique_count" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />

--- a/help_function/src/onedpl_test_exclusive_scan.cpp
+++ b/help_function/src/onedpl_test_exclusive_scan.cpp
@@ -40,6 +40,9 @@ int main(){
     int failed_tests = 0;
     int num_failing = 0;
 
+
+    // These tests assume USM is available, disable when it isn't
+#ifndef DPCT_USM_LEVEL_NONE
     {
         // Test One, test normal call to std::exclusive_scan with std::plus<> and USM allocations
         // create queue
@@ -100,6 +103,7 @@ int main(){
         failed_tests += test_passed(num_failing, test_name);
         num_failing = 0;
     }
+#endif //DPCT_USM_LEVEL_NONE
 
     {
         // Test Two, test normal call to std::exclusive_scan with std::plus<> with overlapping source and destination

--- a/help_function/src/onedpl_test_fill.cpp
+++ b/help_function/src/onedpl_test_fill.cpp
@@ -7,8 +7,6 @@
 //
 // ===----------------------------------------------------------------------===//
 
-#define DPCT_USM_LEVEL_NONE
-
 #include "oneapi/dpl/execution"
 #include "oneapi/dpl/iterator"
 #include "oneapi/dpl/algorithm"

--- a/help_function/src/onedpl_test_for_each.cpp
+++ b/help_function/src/onedpl_test_for_each.cpp
@@ -6,7 +6,6 @@
 //
 //
 // ===----------------------------------------------------------------------===//
-#define DPCT_USM_LEVEL_NONE
 
 #include "oneapi/dpl/execution"
 #include "oneapi/dpl/iterator"

--- a/help_function/src/onedpl_test_for_each.cpp
+++ b/help_function/src/onedpl_test_for_each.cpp
@@ -6,6 +6,7 @@
 //
 //
 // ===----------------------------------------------------------------------===//
+#define DPCT_USM_LEVEL_NONE
 
 #include "oneapi/dpl/execution"
 #include "oneapi/dpl/iterator"
@@ -366,17 +367,11 @@ int main() {
         // test 1/1
 
         // create device_vector and src vector
-        dpct::device_vector<int> dv(8);
         std::vector<int> src(8);
 
         src[0] = -3; src[1] = -2; src[2] = 1; src[3] = 0; src[4] = -1; src[5] = -4; src[6] = 2; src[7] = 3;
         // src: { -3, -2, 1, 0, -1, -4, 2, 3 }
-
-        // copy from src to dv
-        dpct::get_default_queue().submit([&](sycl::handler& h) {
-            h.memcpy(dv.data(), src.data(), 8 * sizeof(int));
-        });
-        dpct::get_default_queue().wait();
+        dpct::device_vector<int> dv(src);
 
         {
             // call algorithm on dv
@@ -389,24 +384,18 @@ int main() {
             );
         }
 
-        dpct::get_default_queue().submit([&](sycl::handler& h) {
-            // copy dv back to src
-            h.memcpy(src.data(), dv.data(), 8 * sizeof(int));
-        });
-        dpct::get_default_queue().wait();
-
         // check that src is now { 3, 2, 1, 0, -1, -4, 2, 3 }
         // actual result is no change in src elements
         test_name = "std::for_each using device_vector";
 
-        num_failing += ASSERT_EQUAL(test_name, src[0], 3);
-        num_failing += ASSERT_EQUAL(test_name, src[1], 2);
-        num_failing += ASSERT_EQUAL(test_name, src[2], 1);
-        num_failing += ASSERT_EQUAL(test_name, src[3], 0);
-        num_failing += ASSERT_EQUAL(test_name, src[4], -1);
-        num_failing += ASSERT_EQUAL(test_name, src[5], -4);
-        num_failing += ASSERT_EQUAL(test_name, src[6], 2);
-        num_failing += ASSERT_EQUAL(test_name, src[7], 3);
+        num_failing += ASSERT_EQUAL(test_name, dv[0], 3);
+        num_failing += ASSERT_EQUAL(test_name, dv[1], 2);
+        num_failing += ASSERT_EQUAL(test_name, dv[2], 1);
+        num_failing += ASSERT_EQUAL(test_name, dv[3], 0);
+        num_failing += ASSERT_EQUAL(test_name, dv[4], -1);
+        num_failing += ASSERT_EQUAL(test_name, dv[5], -4);
+        num_failing += ASSERT_EQUAL(test_name, dv[6], 2);
+        num_failing += ASSERT_EQUAL(test_name, dv[7], 3);
 
         failed_tests += test_passed(num_failing, test_name);
         num_failing = 0;

--- a/help_function/src/onedpl_test_sort_by_key.cpp
+++ b/help_function/src/onedpl_test_sort_by_key.cpp
@@ -6,6 +6,7 @@
 //
 //
 // ===----------------------------------------------------------------------===//
+#define DPCT_USM_LEVEL_NONE
 
 #include <oneapi/dpl/execution>
 
@@ -144,6 +145,8 @@ int main() {
         }
     }
 
+    // These tests assume USM is available, disable when it isn't
+#ifndef DPCT_USM_LEVEL_NONE
     {
     // Test One, call to dpct::sort using USM allocations
         // create queue
@@ -199,6 +202,7 @@ int main() {
         failed_tests += test_passed(num_failing, test_name);
         num_failing = 0;
     }
+#endif //DPCT_USM_LEVEL_NONE
 
     {
     // Test Two, test calls to dpct::sort using device vectors
@@ -218,10 +222,6 @@ int main() {
             // values is now = {19, 10, 18, 11, 13, 17, 15, 12, 16, 14}
         }
 
-        {
-            int check_keys[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-            int check_values[10] = {19, 10, 18, 11, 13, 17, 15, 12, 16, 14};
-            test_name = "sort using device_vector";
 
             // check that values and keys are correct
 
@@ -274,6 +274,8 @@ int main() {
         }
     }
 
+    // These tests assume USM is available, disable when it isn't
+#ifndef DPCT_USM_LEVEL_NONE
     {
     // Test Three, call to dpct::stable_sort using USM allocations
         // create queue
@@ -331,6 +333,7 @@ int main() {
         failed_tests += test_passed(num_failing, test_name);
         num_failing = 0;
     }
+#endif // DPCT_USM_LEVEL_NONE
 
     { // Test Four, test calls to dpct::stable_sort with duplicate key values
         sycl::buffer<int, 1> keys_buf{ sycl::range<1>(16) };

--- a/help_function/src/onedpl_test_sort_by_key.cpp
+++ b/help_function/src/onedpl_test_sort_by_key.cpp
@@ -221,6 +221,10 @@ int main() {
             // values is now = {19, 10, 18, 11, 13, 17, 15, 12, 16, 14}
         }
 
+        {
+            int check_keys[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+            int check_values[10] = {19, 10, 18, 11, 13, 17, 15, 12, 16, 14};
+            test_name = "sort using device_vector";
 
             // check that values and keys are correct
 

--- a/help_function/src/onedpl_test_sort_by_key.cpp
+++ b/help_function/src/onedpl_test_sort_by_key.cpp
@@ -6,7 +6,6 @@
 //
 //
 // ===----------------------------------------------------------------------===//
-#define DPCT_USM_LEVEL_NONE
 
 #include <oneapi/dpl/execution>
 


### PR DESCRIPTION
A number of `onedpl_test_*` tests assume the presence of USM.  

This PR attempts to address the usage of `dpct::device_vector` and `dpct::device_pointer` and assumptions that USM is available in a few ways:

1) In `onedpl_test_copy_if`, `onedpl_test_fill.cpp`, `onedpl_test_sort_by_key.cpp`, `onedpl_test_for_each.cpp` and `onedpl_test_transform_reduce.cpp` : we change the usage pattern of some tests to use `dpct::device_vector` in such a way to fit both USM and USM_NONE options

2) In `onedpl_test_exclusive_scan.cpp`, `onedpl_test_fill.cpp`, and `onedpl_test_sort_by_key.cpp`: we add checks to avoid some tests when `DPCT_USM_LEVEL_NONE` is defined.

3) This PR also adds 2 tests which were missing from `help_function/help_function.xml`: `onedpl_test_device_malloc_free`, ~~and `onedpl_test_transform`~~, but only to run for the option where USM is present.  
Edit: removing `onedpl_test_transform` as it is failing in all cases it seems.  It seems this should be dealt with separately.

4) This PR also changes `onedpl_test_uninitialized_fill` to only run with USM available, as all of its tests assume the USM is available.

Closing #240 in favor of this PR which has a larger scope.