### PR TITLE
[CI][GHA]Will not launch CI testing for draft PR

### DIFF
--- a/.github/workflows/ci_lin.yml
+++ b/.github/workflows/ci_lin.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - SYCLomatic
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   BUILD_CONCURRENCY: 2
@@ -15,8 +16,7 @@ jobs:
   linux-test:
     name: linux-test-${{ matrix.test_suite }}-cpu
     runs-on: lin_ci_test
-    if: |
-      always() 
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - SYCLomatic
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   BUILD_CONCURRENCY: 2
@@ -13,6 +14,7 @@ env:
 jobs:
   windows-test:
     name: windows-test-${{ matrix.test_suite }}-cpu
+    if: github.event.pull_request.draft == false
     runs-on: win_ci_test
 
     strategy:


### PR DESCRIPTION
This change will make CI tests not be launched if PR is draft status.
And will be launched automatically if the PR "Ready to Review"
Verified by fork internal run:
https://github.com/DoyleLi/SYCLomatic/pull/3