### PR TITLE
[SYCLomatic] Add test using cg::tiled_partition<32> functions

### DIFF
--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -43,7 +43,8 @@ exec_tests = ['thrust-vector-2', 'thrust-binary-search', 'thrust-count', 'thrust
               'thrust_set_difference', 'thrust_set_difference_by_key', 'thrust_set_intersection_by_key', 'thrust_stable_sort',
               'thrust_tabulate', 'thrust_for_each_n', 'device_info', 'defaultStream', 'cudnn-rnn', 'feature_profiling',
               'thrust_raw_reference_cast', 'thrust_partition_copy', 'thrust_stable_partition_copy',
-              'thrust_stable_partition', 'thrust_remove']
+              'thrust_stable_partition', 'thrust_remove',
+              'cooperative_groups']
 
 def setup_test():
     return True


### PR DESCRIPTION
E2E test for: https://github.com/oneapi-src/SYCLomatic/pull/759

This PR adds a test for `tiled_partition<32>` to exercise the different migration behavior compared to `tiled_partition<{1,2,4,8,16}>`.