### PR TITLE
Re-enable kernel_library test on Windows.

### DIFF
--- a/features/config/TEMPLATE_kernel_library.xml
+++ b/features/config/TEMPLATE_kernel_library.xml
@@ -5,7 +5,4 @@
     <files>
         <file path="feature_case/kernel_library" />
     </files>
-    <rules>
-        <platformRule OSFamily="Windows" runOnThisPlatform="false" />
-    </rules>
 </test>


### PR DESCRIPTION
Could not re-create error when test was run by hand on Windows.

Signed-off-by: Lu, John [john.lu@intel.com](mailto:john.lu@intel.com)