### PR TITLE
[SYCLomatic #770] Disable bfloat16 case for refining the migration of bfloat16 type.

### DIFF
--- a/features/feature_case/math/math-bfloat16.cu
+++ b/features/feature_case/math/math-bfloat16.cu
@@ -1,11 +1,11 @@
-// ====------ math-bfloat16.cu---------- *- CUDA -* ----===////
+// ====-------------- math-bfloat16.cu---------- *- CUDA -* -------------===////
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //
-// ===----------------------------------------------------------------------===//
+// ===---------------------------------------------------------------------===//
 
 #include <cuda.h>
 #include <cuda_bf16.h>
@@ -29,10 +29,8 @@ __global__ void testMathFunctions(char *const TestResults) {
   const float f32 = __bfloat162float(bf16);
 
   // Check that the intermediate bfloat16 value has the expected byte
-  // representation. The CUDA and SYCL values differ due to a difference in
-  // the rounding mode used:
-  //   - CUDA: round-to-nearest-even mode
-  //   - SYCL: round-to-zero mode
+  // representation. The CUDA and SYCL values both use round-to-nearest-even
+  // rounding mode.
 #ifdef DPCT_COMPATIBILITY_TEMP
   TestResults[0] = (convertToU16(bf16) == 0x4048);
 #else

--- a/features/features.xml
+++ b/features/features.xml
@@ -68,7 +68,7 @@
     <test testName="cublasTtrmmLegacy" configFile="config/TEMPLATE_cuBlas.xml" />
     <test testName="cublas-usm-legacy" configFile="config/TEMPLATE_cuBlas.xml" />
     <test testName="cublas-usm" configFile="config/TEMPLATE_cuBlas.xml" />
-    <test testName="math-bfloat16" configFile="config/TEMPLATE_math_bfloat16.xml" />
+<!--    <test testName="math-bfloat16" configFile="config/TEMPLATE_math_bfloat16.xml" />-->
     <test testName="math-direct" configFile="config/TEMPLATE_math.xml" />
     <test testName="math-drcp" configFile="config/TEMPLATE_math_drcp.xml"  splitGroup="double" />
     <test testName="math-emu" configFile="config/TEMPLATE_math.xml" />


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com