### PR TITLE
[SYCLomatic #770] Enable bfloat16 case after refining the migration of bfloat16 type.

### DIFF
--- a/features/feature_case/math/math-bfloat16.cu
+++ b/features/feature_case/math/math-bfloat16.cu
@@ -31,11 +31,7 @@ __global__ void testMathFunctions(char *const TestResults) {
   // Check that the intermediate bfloat16 value has the expected byte
   // representation. The CUDA and SYCL values both use round-to-nearest-even
   // rounding mode.
-#ifdef DPCT_COMPATIBILITY_TEMP
-  TestResults[0] = (convertToU16(bf16) == 0x4048);
-#else
   TestResults[0] = (convertToU16(bf16) == 0x4049);
-#endif
 
   // Check that the converted value is close to the original. The two values
   // may differ slightly due to the loss of precision during type conversion.

--- a/features/features.xml
+++ b/features/features.xml
@@ -71,7 +71,7 @@
     <test testName="cublasTtrmmLegacy" configFile="config/TEMPLATE_cuBlas.xml" />
     <test testName="cublas-usm-legacy" configFile="config/TEMPLATE_cuBlas.xml" />
     <test testName="cublas-usm" configFile="config/TEMPLATE_cuBlas.xml" />
-<!--    <test testName="math-bfloat16" configFile="config/TEMPLATE_math_bfloat16.xml" />-->
+    <test testName="math-bfloat16" configFile="config/TEMPLATE_math_bfloat16.xml" />
     <test testName="math-direct" configFile="config/TEMPLATE_math.xml" />
     <test testName="math-drcp" configFile="config/TEMPLATE_math_drcp.xml"  splitGroup="double" />
     <test testName="math-emu" configFile="config/TEMPLATE_math.xml" />


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com