### PR TITLE
[SYCLomatic] Enable non-USM test for some thrust APIs

### DIFF
--- a/features/config/TEMPLATE_thrust_exec_disable_noneusm.xml
+++ b/features/config/TEMPLATE_thrust_exec_disable_noneusm.xml
@@ -7,6 +7,7 @@
         <file path="feature_case/thrust/report.h" />
     </files>
     <rules>
+        <optlevelRule excludeOptlevelNameString="usmnone" />
         <platformRule OSFamily="Linux" kit="CUDA9.2" kitRange="OLDER" runOnThisPlatform="false"/>
         <platformRule OSFamily="Windows" kit="CUDA9.2" kitRange="OLDER" runOnThisPlatform="false"/>
     </rules>

--- a/features/features.xml
+++ b/features/features.xml
@@ -14,7 +14,7 @@
     <test testName="thrust-copy" configFile="config/TEMPLATE_thrust_exec.xml" />
     <!-- <test testName="thrust-qmc" configFile="config/thrust-qmc.xml" splitGroup="double"/> -->
     <test testName="thrust-transform-if" configFile="config/TEMPLATE_thrust_exec.xml" />
-    <test testName="thrust-policy" configFile="config/TEMPLATE_thrust_exec.xml" />
+    <test testName="thrust-policy" configFile="config/TEMPLATE_thrust_exec_disable_noneusm.xml" />
     <test testName="thrust-list" configFile="config/TEMPLATE_thrust_exec.xml" />
     <test testName="thrust-gather" configFile="config/TEMPLATE_thrust_exec.xml" />
     <test testName="thrust-scatter" configFile="config/TEMPLATE_thrust_exec.xml" />


### PR DESCRIPTION
non-USM test enabled for thrust test cases:
thrust-vector-2
thrust-binary-search
thrust-count
thrust-copy
thrust-transform-if
thrust-list
thrust-gather
thrust-scatter
thrust-unique_by_key_copy
thrust-for-hypre
thrust-find
thrust-sort_by_key
thrust-inner_product
thrust-reduce_by_key