### PR TITLE
[SYCLomatic #843] Include dnnl_utils.hpp in open-source-mkl-compile test.

### DIFF
--- a/behavior_tests/src/open-source-mkl-compile/main.dp.cpp
+++ b/behavior_tests/src/open-source-mkl-compile/main.dp.cpp
@@ -1,3 +1,12 @@
+// ====------------------ main.dp.cpp---------- *- C++ -*------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===---------------------------------------------------------------------===//
+
 #include <oneapi/dpl/execution> // Need add this header before sycl header.
 
 #include <dpct/dpct.hpp>
@@ -6,7 +15,7 @@
 #include <dpct/blas_utils.hpp>
 #include <dpct/ccl_utils.hpp>
 #include <dpct/device.hpp>
-// #include <dpct/dnnl_utils.hpp> // TODO: Add this line after dnn bug fix.
+#include <dpct/dnnl_utils.hpp>
 #include <dpct/dpl_utils.hpp>
 #include <dpct/fft_utils.hpp>
 #include <dpct/image.hpp>


### PR DESCRIPTION
Signed-off-by: Tang, Jiajun jiajun.tang@intel.com