### PR TITLE
[SYCLomatic #884] Tests for device_vector being AllocatorAwareContainer

### DIFF
--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -6,6 +6,7 @@
     <test testName="array_copy" configFile="config/TEMPLATE_help_function.xml" />
     <test testName="assign_device_vector" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="move_device_vector" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="swap_device_vector" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="atomic_add_float" configFile="config/TEMPLATE_help_function.xml" />
     <test testName="atomic_fetch_compare_inc" configFile="config/TEMPLATE_help_function.xml" />
     <test testName="async_exception" configFile="config/TEMPLATE_help_function.xml" />

--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -4,9 +4,9 @@
   <description>Test the helper function</description>
   <tests>
     <test testName="array_copy" configFile="config/TEMPLATE_help_function.xml" />
-    <test testName="assign_device_vector" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
-    <test testName="move_device_vector" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
-    <test testName="swap_device_vector" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="assign_device_vector" configFile="config/TEMPLATE_help_function_usm.xml" />
+    <test testName="move_device_vector" configFile="config/TEMPLATE_help_function_usm.xml" />
+    <test testName="swap_device_vector" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="atomic_add_float" configFile="config/TEMPLATE_help_function.xml" />
     <test testName="atomic_fetch_compare_inc" configFile="config/TEMPLATE_help_function.xml" />
     <test testName="async_exception" configFile="config/TEMPLATE_help_function.xml" />

--- a/help_function/src/assign_device_vector.cpp
+++ b/help_function/src/assign_device_vector.cpp
@@ -4,6 +4,73 @@
 #include <dpct/dpct.hpp>
 #include <dpct/dpl_utils.hpp>
 
+template <typename Vector>
+bool verify(Vector &D, int N, int V) {
+  if (D.size() != N)
+  {
+    std::cout<<"size mismatch"<<std::endl;
+    return false;
+  }
+  for (int i = 0; i < N; ++i)
+    if (D[i] != V)
+    {
+      std::cout<<"value mismatch "<<D[i]<< " != "<<V<<std::endl;
+      return false;
+    }
+  return true;
+}
+
+
+static int num_constructed_prop = 0;
+static int num_destroyed_prop = 0;
+static int num_constructed_no_prop = 0;
+static int num_destroyed_no_prop = 0;
+
+template <typename T>
+class AllocWithNoCopyPropagation : public sycl::usm_allocator<T, sycl::usm::alloc::shared> {
+  public:
+  AllocWithNoCopyPropagation(const sycl::context &Ctxt, const sycl::device &Dev,
+                                     const sycl::property_list &PropList = {}) 
+                       : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Ctxt, Dev, PropList)
+  {}
+  AllocWithNoCopyPropagation(const sycl::queue &Q, const sycl::property_list &PropList = {}) 
+    : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Q, PropList)
+  {}
+  
+  AllocWithNoCopyPropagation(const AllocWithNoCopyPropagation& other)
+    : sycl::usm_allocator<T, sycl::usm::alloc::shared>(other)
+  {}
+
+  typedef ::std::false_type propagate_on_container_copy_assignment;
+  static void construct(T *p) { ::new((void*)p) T();  num_constructed_no_prop++;}
+  template <typename _Arg>
+  static void construct(T *p, _Arg arg) { ::new((void*)p) T(arg); num_constructed_no_prop++;}
+  static void destroy(T *p) { p->~T(); num_destroyed_no_prop++;}
+  
+};
+
+template <typename T>
+class AllocWithCopyPropagation : public sycl::usm_allocator<T, sycl::usm::alloc::shared> {
+  public:
+  AllocWithCopyPropagation(const sycl::context &Ctxt, const sycl::device &Dev,
+                                     const sycl::property_list &PropList = {})
+                       : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Ctxt, Dev, PropList)
+  {}
+  AllocWithCopyPropagation(const sycl::queue &Q, const sycl::property_list &PropList = {}) 
+    : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Q, PropList)
+  {}
+  
+  AllocWithCopyPropagation(const AllocWithCopyPropagation& other)
+    : sycl::usm_allocator<T, sycl::usm::alloc::shared>(other)
+  {}
+
+  typedef ::std::true_type propagate_on_container_copy_assignment;
+  static void construct(T *p) { ::new((void*)p) T();  num_constructed_prop++;}
+  template <typename _Arg>
+  static void construct(T *p, _Arg arg) { ::new((void*)p) T(arg); num_constructed_prop++;}
+  static void destroy(T *p) { p->~T(); num_destroyed_prop++;}
+};
+
 int main(void)
 {
     // H has storage for 4 integers
@@ -23,8 +90,59 @@ int main(void)
     D[1] = 88;
     
     H = D;
-    if (H[0] == 99 && H[1] == 88)
-      return 0;
-    else
+    if (H[0] != 99 || H[1] != 88)
       return 1;
+
+    constexpr int N = 5;
+    constexpr int V = 99;
+    dpct::device_vector<int> D1(N, V);
+
+    AllocWithNoCopyPropagation<int> alloc_no_copy_prop1(dpct::get_default_queue());
+    AllocWithNoCopyPropagation<int> alloc_no_copy_prop2(dpct::get_default_queue());
+    
+    //should construct 5 ints from D1 in the new allocation space
+    dpct::device_vector<int, AllocWithNoCopyPropagation<int>> D2(std::move(D1), alloc_no_copy_prop1);
+    if (!verify(D2, N, V)) {
+        std::cout<<"Failed move of default allocator to AllocWithNoCopyProp"<<std::endl;
+        return 1;
+    }
+    //Should allocate and construct 10 int{}
+    dpct::device_vector<int, AllocWithNoCopyPropagation<int>> D3(10, alloc_no_copy_prop2);
+    //since there is no copy propagation, we only destroy the excess, not all 10 elements, and we copy the N elements
+    D3 = D2; 
+    if (!verify(D3, N, V)) {
+        std::cout<<"Failed move assign of AllocWithNoCopyProp"<<std::endl;
+        return 1;
+    }
+
+    if (num_constructed_no_prop != 15 && num_destroyed_no_prop != 5)
+    {
+        std::cout<<"Allocator without copy propagation is copying incorrectly: ["<<num_constructed_no_prop<<", "<<num_destroyed_no_prop<<"]"<<std::endl;
+        return 1;
+    }
+
+    AllocWithCopyPropagation<int> alloc_copy_prop1(dpct::get_default_queue());
+    AllocWithCopyPropagation<int> alloc_copy_prop2(dpct::get_default_queue());
+    
+    //Should allocate 5 ints from D3 in the new allocation space
+    dpct::device_vector<int, AllocWithCopyPropagation<int>> D4(std::move(D3), alloc_copy_prop1);
+    if (!verify(D4, N, V)) {
+        std::cout<<"Failed move of AllocWithNoCopyProp to AllocWithCopyProp"<<std::endl;
+        return 1;
+    }
+    //Should allocate and construct 10 int{}
+    dpct::device_vector<int, AllocWithCopyPropagation<int>> D5(10, alloc_copy_prop2);
+    //since there is copy propagation, we destroy all 10 elements, and use the propagated allocator to construct
+    // 5 new elements
+    D5 = D4; 
+    if (!verify(D5, N, V)) {
+        std::cout<<"Failed copy assign of AllocWithCopyProp"<<std::endl;
+        return 1;
+    }
+
+    if (num_constructed_prop != 20 && num_destroyed_prop != 10)
+    {
+        std::cout<<"Allocator with copy propagation is copying incorrectly: ["<<num_constructed_prop<<", "<<num_destroyed_prop<<"]"<<std::endl;
+        return 1;
+    }
 }

--- a/help_function/src/assign_device_vector.cpp
+++ b/help_function/src/assign_device_vector.cpp
@@ -1,3 +1,12 @@
+// ====------ assign_device_vector.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <sycl.hpp>

--- a/help_function/src/move_device_vector.cpp
+++ b/help_function/src/move_device_vector.cpp
@@ -4,14 +4,72 @@
 #include <dpct/dpct.hpp>
 #include <dpct/dpl_utils.hpp>
 
-bool verify(dpct::device_vector<int> &D, int N, int V) {
+template <typename Vector>
+bool verify(Vector &D, int N, int V) {
   if (D.size() != N)
+  {
+    std::cout<<"size mismatch"<<std::endl;
     return false;
+  }
   for (int i = 0; i < N; ++i)
     if (D[i] != V)
+    {
+      std::cout<<"value mismatch "<<D[i]<< " != "<<V<<std::endl;
       return false;
+    }
   return true;
 }
+
+static int num_constructed_prop = 0;
+static int num_destroyed_prop = 0;
+static int num_constructed_no_prop = 0;
+static int num_destroyed_no_prop = 0;
+
+template <typename T>
+class AllocWithNoMovePropagation : public sycl::usm_allocator<T, sycl::usm::alloc::shared> {
+  public:
+  AllocWithNoMovePropagation(const sycl::context &Ctxt, const sycl::device &Dev,
+                                     const sycl::property_list &PropList = {}) 
+                       : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Ctxt, Dev, PropList)
+  {}
+  AllocWithNoMovePropagation(const sycl::queue &Q, const sycl::property_list &PropList = {}) 
+    : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Q, PropList)
+  {}
+  
+  AllocWithNoMovePropagation(const AllocWithNoMovePropagation& other)
+    : sycl::usm_allocator<T, sycl::usm::alloc::shared>(other)
+  {}
+
+  typedef ::std::false_type propagate_on_container_move_assignment;
+  static void construct(T *p) { ::new((void*)p) T();  num_constructed_no_prop++;}
+  template <typename _Arg>
+  static void construct(T *p, _Arg arg) { ::new((void*)p) T(arg); num_constructed_no_prop++;}
+  static void destroy(T *p) { p->~T(); num_destroyed_no_prop++;}
+  
+};
+
+template <typename T>
+class AllocWithMovePropagation : public sycl::usm_allocator<T, sycl::usm::alloc::shared> {
+  public:
+  AllocWithMovePropagation(const sycl::context &Ctxt, const sycl::device &Dev,
+                                     const sycl::property_list &PropList = {})
+                       : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Ctxt, Dev, PropList)
+  {}
+  AllocWithMovePropagation(const sycl::queue &Q, const sycl::property_list &PropList = {}) 
+    : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Q, PropList)
+  {}
+  
+  AllocWithMovePropagation(const AllocWithMovePropagation& other)
+    : sycl::usm_allocator<T, sycl::usm::alloc::shared>(other)
+  {}
+
+  typedef ::std::true_type propagate_on_container_move_assignment;
+  static void construct(T *p) { ::new((void*)p) T();  num_constructed_prop++;}
+  template <typename _Arg>
+  static void construct(T *p, _Arg arg) { ::new((void*)p) T(arg); num_constructed_prop++;}
+  static void destroy(T *p) { p->~T(); num_destroyed_prop++;}
+};
+
 
 int main(void) {
   constexpr int N = 4;
@@ -23,9 +81,59 @@ int main(void) {
   }
   // Move assign to D2.
   dpct::device_vector<int> D2;
+  auto alloc = D2.get_allocator();
   D2 = std::move(dpct::device_vector<int>(N, V));
   if (!verify(D2, N, V)) {
     return 1;
   }
+  AllocWithNoMovePropagation<int> alloc_no_move_prop(dpct::get_default_queue());
+  
+  dpct::device_vector<int, AllocWithNoMovePropagation<int>> D3(std::move(D2), alloc_no_move_prop);
+  if (!verify(D3, N, V)) {
+    std::cout<<"Failed move of default allocator to AllocWithNoMoveProp"<<std::endl;
+    return 1;
+  }
+  dpct::device_vector<int, AllocWithNoMovePropagation<int>> D4(std::move(D3));
+  if (!verify(D4, N, V)) {
+    std::cout<<"Failed move of AllocWithNoMoveProp"<<std::endl;
+    return 1;
+  }
+  dpct::device_vector<int, AllocWithNoMovePropagation<int>> D5;
+  D5 = std::move(D4);
+  if (!verify(D5, N, V)) {
+    std::cout<<"Failed move assign of AllocWithNoMoveProp"<<std::endl;
+    return 1;
+  }
+
+  if (num_constructed_no_prop != 8 && num_destroyed_no_prop != 4)
+  {
+    std::cout<<"Allocator without move propagation is moving incorrectly: ["<<num_constructed_no_prop<<", "<<num_destroyed_no_prop<<"]"<<std::endl;
+    return 1;
+  }
+
+  AllocWithMovePropagation<int> alloc_move_prop(dpct::get_default_queue());
+
+  dpct::device_vector<int, AllocWithMovePropagation<int>> D6(std::move(D5), alloc_move_prop);
+  if (!verify(D6, N, V)) {
+    std::cout<<"Failed move of AllocWithNoMoveProp to AllocWithMoveProp"<<std::endl;
+    return 1;
+  }
+  dpct::device_vector<int, AllocWithMovePropagation<int>> D7;
+  D7 = std::move(D6);
+  if (!verify(D7, N, V)) {
+    std::cout<<"Failed move assign of AllocWithMoveProp"<<std::endl;
+    return 1;
+  }
+  dpct::device_vector<int, AllocWithMovePropagation<int>> D8(std::move(D7));
+  if (!verify(D8, N, V)) {
+    std::cout<<"Failed move of AllocWithMoveProp"<<std::endl;
+    return 1;
+  }
+  if (num_constructed_prop != 4 && num_destroyed_prop != 0)
+  {
+    std::cout<<"Allocator with move propagation is moving incorrectly: ["<<num_constructed_prop<<", "<<num_destroyed_prop<<"]"<<std::endl;
+    return 1;
+  }
+
   return 0;
 }

--- a/help_function/src/move_device_vector.cpp
+++ b/help_function/src/move_device_vector.cpp
@@ -1,3 +1,12 @@
+// ====------ move_device_vector.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <sycl.hpp>

--- a/help_function/src/move_device_vector.cpp
+++ b/help_function/src/move_device_vector.cpp
@@ -20,6 +20,8 @@ bool verify(Vector &D, int N, int V) {
   return true;
 }
 
+// adding these global variables to track construction and destruction
+//  using custom allocators with different settings.
 static int num_constructed_prop = 0;
 static int num_destroyed_prop = 0;
 static int num_constructed_no_prop = 0;
@@ -86,6 +88,8 @@ int main(void) {
   if (!verify(D2, N, V)) {
     return 1;
   }
+
+  // check appropriate effect of Allocator::propagate_on_container_move_assignment
   AllocWithNoMovePropagation<int> alloc_no_move_prop(dpct::get_default_queue());
   
   dpct::device_vector<int, AllocWithNoMovePropagation<int>> D3(std::move(D2), alloc_no_move_prop);
@@ -107,7 +111,8 @@ int main(void) {
 
   if (num_constructed_no_prop != 8 && num_destroyed_no_prop != 4)
   {
-    std::cout<<"Allocator without move propagation is moving incorrectly: ["<<num_constructed_no_prop<<", "<<num_destroyed_no_prop<<"]"<<std::endl;
+    std::cout<<"Allocator without move propagation is moving incorrectly: ["
+             <<num_constructed_no_prop<<", "<<num_destroyed_no_prop<<"]"<<std::endl;
     return 1;
   }
 
@@ -131,7 +136,8 @@ int main(void) {
   }
   if (num_constructed_prop != 4 && num_destroyed_prop != 0)
   {
-    std::cout<<"Allocator with move propagation is moving incorrectly: ["<<num_constructed_prop<<", "<<num_destroyed_prop<<"]"<<std::endl;
+    std::cout<<"Allocator with move propagation is moving incorrectly: ["
+             <<num_constructed_prop<<", "<<num_destroyed_prop<<"]"<<std::endl;
     return 1;
   }
 

--- a/help_function/src/onedpl_test_vector.cpp
+++ b/help_function/src/onedpl_test_vector.cpp
@@ -46,13 +46,13 @@ int test_passed(int failing_elems, std::string test_name) {
 
 
 template <typename T>
-class my_allocator_with_custom_construct : public dpct::internal::usm_device_allocator<T> {
+class my_allocator_with_custom_construct : public sycl::usm_allocator<T, sycl::usm::alloc::shared> {
   public:
   my_allocator_with_custom_construct(const sycl::context &Ctxt, const sycl::device &Dev,
                                      const sycl::property_list &PropList = {}) 
-                       : dpct::internal::usm_device_allocator<T>(Ctxt, Dev, PropList) {}
+                       : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Ctxt, Dev, PropList) {}
   my_allocator_with_custom_construct(const sycl::queue &Q, const sycl::property_list &PropList = {}) 
-    : dpct::internal::usm_device_allocator<T>(Q, PropList)
+    : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Q, PropList)
   {}
 
   static void construct(T *p) { ::new((void*)p) T(6); }

--- a/help_function/src/onedpl_test_vector.cpp
+++ b/help_function/src/onedpl_test_vector.cpp
@@ -48,7 +48,9 @@ int test_passed(int failing_elems, std::string test_name) {
 template <typename T>
 class my_allocator_with_custom_construct : public dpct::internal::usm_device_allocator<T> {
   public:
-  my_allocator_with_custom_construct() {}
+  my_allocator_with_custom_construct(const sycl::context &Ctxt, const sycl::device &Dev,
+                                     const sycl::property_list &PropList = {}) 
+                       : dpct::internal::usm_device_allocator<T>(Ctxt, Dev, PropList) {}
   my_allocator_with_custom_construct(const sycl::queue &Q, const sycl::property_list &PropList = {}) 
     : dpct::internal::usm_device_allocator<T>(Q, PropList)
   {}

--- a/help_function/src/onedpl_test_vector.cpp
+++ b/help_function/src/onedpl_test_vector.cpp
@@ -108,6 +108,7 @@ int main() {
     v4.insert(v4.begin(), 2, *(v2.begin()) - 111);
     v4.insert(v4.begin(), v2.begin(), v2.begin() + 2);
 #endif
+    //insert host side data into the vector
     std::vector<int> host_v(2, 79);
     v4.insert(v4.begin()+3, host_v.begin(), host_v.end());
 

--- a/help_function/src/onedpl_test_vector.cpp
+++ b/help_function/src/onedpl_test_vector.cpp
@@ -194,6 +194,27 @@ int main() {
     failed_tests += test_passed(num_failing, test_name);
     num_failing = 0;
 #endif
+    Vector<T> v7(v5.begin()+3, v5.end()-2);
+    dpct::get_default_queue().wait();
+#ifdef _VERBOSE
+    std::cout << std::endl << "v7: ";
+    for (std::size_t i = 0; i < v7.size(); ++i) {
+        std::cout << v7[i] << " ";  // expected: 79 79 -111 -111 -111 1 2 3
+    }
+    std::cout << std::endl;
+#else
+   test_name = "v7 = modified v5";
+
+    num_failing += ASSERT_ARRAY_EQUAL(test_name, v7[0], 79);
+    num_failing += ASSERT_ARRAY_EQUAL(test_name, v7[1], 79);
+    num_failing += ASSERT_ARRAY_EQUAL(test_name, v7[2], -111);
+    num_failing += ASSERT_ARRAY_EQUAL(test_name, v7[3], -111);
+    num_failing += ASSERT_ARRAY_EQUAL(test_name, v7[4], 1);
+    num_failing += ASSERT_ARRAY_EQUAL(test_name, v7[5], 2);
+    num_failing += ASSERT_ARRAY_EQUAL(test_name, v7[6], 3);
+#endif
+
+
     { // Simple test of DPCT vector with PSTL algorithm
         // create buffer
         std::vector<int64_t> src(8);

--- a/help_function/src/onedpl_test_vector.cpp
+++ b/help_function/src/onedpl_test_vector.cpp
@@ -295,8 +295,29 @@ int main() {
     num_failing = 0;
     test_name = "inserting host iterators";
     {
+        std::vector<int64_t> src(8, 99);
+        std::vector<int64_t> src2(2, 2);
+        std::vector<int64_t> src3(3, 33);
 
-        
+        dpct::device_vector<int64_t> dst = src;
+        dst.insert(dst.end(), src2.begin(), src2.end());
+
+        dst.insert(dst.begin() + 3, src3.begin(), src3.end());
+
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst.size(), 13);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[0], 99);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[1], 99);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[2], 99);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[3], 33);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[4], 33);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[5], 33);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[6], 99);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[7], 99);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[8], 99);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[9], 99);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[10], 99);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[11], 2);
+        num_failing += ASSERT_ARRAY_EQUAL(test_name, dst[12], 2);
     }
 
 

--- a/help_function/src/swap_device_vector.cpp
+++ b/help_function/src/swap_device_vector.cpp
@@ -22,6 +22,8 @@ verify(Vector& D, int N, int V)
     return true;
 }
 
+//adding these global variables to track construction and destruction
+// using custom allocators with different settings.
 static int num_constructed_prop = 0;
 static int num_destroyed_prop = 0;
 static int num_constructed_no_prop = 0;
@@ -118,6 +120,8 @@ main(void)
     constexpr int V2 = 98;
     dpct::device_vector<int> D1(N1, V1);
 
+  // check appropriate effect of Allocator::propagate_on_container_swap
+
     AllocWithNoSwapPropagation<int> alloc_no_swap_prop1(dpct::get_default_queue());
     AllocWithNoSwapPropagation<int> alloc_no_swap_prop2(dpct::get_default_queue());
 
@@ -141,8 +145,8 @@ main(void)
 
     if (num_constructed_no_prop != 14 && num_destroyed_no_prop != 4)
     {
-        std::cout << "Allocator without swap propagation is swaping incorrectly: [" << num_constructed_no_prop << ", "
-                  << num_destroyed_no_prop << "]" << std::endl;
+        std::cout << "Allocator without swap propagation is swaping incorrectly: [14, 4] != [" 
+                  << num_constructed_no_prop << ", "<< num_destroyed_no_prop << "]" << std::endl;
         return 1;
     }
 
@@ -172,8 +176,8 @@ main(void)
 
     if (num_constructed_prop != 10 && num_destroyed_prop != 0)
     {
-        std::cout << "Allocator with swap propagation is swaping incorrectly: [" << num_constructed_prop << ", "
-                  << num_destroyed_prop << "]" << std::endl;
+        std::cout << "Allocator with swap propagation is swaping incorrectly: [10, 0] != ["
+                  << num_constructed_prop << ", "<< num_destroyed_prop << "]" << std::endl;
         return 1;
     }
     return 0;

--- a/help_function/src/swap_device_vector.cpp
+++ b/help_function/src/swap_device_vector.cpp
@@ -1,3 +1,12 @@
+// ====------ swap_device_vector.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <sycl.hpp>

--- a/help_function/src/swap_device_vector.cpp
+++ b/help_function/src/swap_device_vector.cpp
@@ -1,0 +1,180 @@
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/algorithm>
+#include <sycl.hpp>
+#include <dpct/dpct.hpp>
+#include <dpct/dpl_utils.hpp>
+
+template <typename Vector>
+bool
+verify(Vector& D, int N, int V)
+{
+    if (D.size() != N)
+    {
+        std::cout << "size mismatch" << std::endl;
+        return false;
+    }
+    for (int i = 0; i < N; ++i)
+        if (D[i] != V)
+        {
+            std::cout << "value mismatch " << D[i] << " != " << V << std::endl;
+            return false;
+        }
+    return true;
+}
+
+static int num_constructed_prop = 0;
+static int num_destroyed_prop = 0;
+static int num_constructed_no_prop = 0;
+static int num_destroyed_no_prop = 0;
+
+template <typename T>
+class AllocWithNoSwapPropagation : public sycl::usm_allocator<T, sycl::usm::alloc::shared>
+{
+  public:
+    AllocWithNoSwapPropagation(const sycl::context& Ctxt, const sycl::device& Dev,
+                               const sycl::property_list& PropList = {})
+        : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Ctxt, Dev, PropList)
+    {
+    }
+    AllocWithNoSwapPropagation(const sycl::queue& Q, const sycl::property_list& PropList = {})
+        : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Q, PropList)
+    {
+    }
+
+    AllocWithNoSwapPropagation(const AllocWithNoSwapPropagation& other)
+        : sycl::usm_allocator<T, sycl::usm::alloc::shared>(other)
+    {
+    }
+
+    typedef ::std::false_type propagate_on_container_swap;
+    static void
+    construct(T* p)
+    {
+        ::new ((void*)p) T();
+        num_constructed_no_prop++;
+    }
+    template <typename _Arg>
+    static void
+    construct(T* p, _Arg arg)
+    {
+        ::new ((void*)p) T(arg);
+        num_constructed_no_prop++;
+    }
+    static void
+    destroy(T* p)
+    {
+        p->~T();
+        num_destroyed_no_prop++;
+    }
+};
+
+template <typename T>
+class AllocWithSwapPropagation : public sycl::usm_allocator<T, sycl::usm::alloc::shared>
+{
+  public:
+    AllocWithSwapPropagation(const sycl::context& Ctxt, const sycl::device& Dev,
+                             const sycl::property_list& PropList = {})
+        : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Ctxt, Dev, PropList)
+    {
+    }
+    AllocWithSwapPropagation(const sycl::queue& Q, const sycl::property_list& PropList = {})
+        : sycl::usm_allocator<T, sycl::usm::alloc::shared>(Q, PropList)
+    {
+    }
+
+    AllocWithSwapPropagation(const AllocWithSwapPropagation& other)
+        : sycl::usm_allocator<T, sycl::usm::alloc::shared>(other)
+    {
+    }
+
+    typedef ::std::true_type propagate_on_container_swap;
+    static void
+    construct(T* p)
+    {
+        ::new ((void*)p) T();
+        num_constructed_prop++;
+    }
+    template <typename _Arg>
+    static void
+    construct(T* p, _Arg arg)
+    {
+        ::new ((void*)p) T(arg);
+        num_constructed_prop++;
+    }
+    static void
+    destroy(T* p)
+    {
+        p->~T();
+        num_destroyed_prop++;
+    }
+};
+
+int
+main(void)
+{
+    constexpr int N1 = 3;
+    constexpr int V1 = 99;
+    constexpr int N2 = 7;
+    constexpr int V2 = 98;
+    dpct::device_vector<int> D1(N1, V1);
+
+    AllocWithNoSwapPropagation<int> alloc_no_swap_prop1(dpct::get_default_queue());
+    AllocWithNoSwapPropagation<int> alloc_no_swap_prop2(dpct::get_default_queue());
+
+    //Should allocate and construct N1 int{}
+    dpct::device_vector<int, AllocWithNoSwapPropagation<int>> D2(std::move(D1), alloc_no_swap_prop1);
+    if (!verify(D2, N1, V1))
+    {
+        std::cout << "Failed move of default allocator to AllocWithNoSwapProp" << std::endl;
+        return 1;
+    }
+
+    //Should allocate and construct N2 int{}
+    dpct::device_vector<int, AllocWithNoSwapPropagation<int>> D3(N2, V2, alloc_no_swap_prop2);
+    //since there is no swap propagation, we only destroy the excess
+    D3.swap(D2);
+    if (!verify(D3, N1, V1) || !verify(D2, N2, V2))
+    {
+        std::cout << "Failed swap of AllocWithNoSwapProp" << std::endl;
+        return 1;
+    }
+
+    if (num_constructed_no_prop != 14 && num_destroyed_no_prop != 4)
+    {
+        std::cout << "Allocator without swap propagation is swaping incorrectly: [" << num_constructed_no_prop << ", "
+                  << num_destroyed_no_prop << "]" << std::endl;
+        return 1;
+    }
+
+
+    dpct::device_vector<int> D4(N1, V1);
+
+    AllocWithSwapPropagation<int> alloc_swap_prop1(dpct::get_default_queue());
+    AllocWithSwapPropagation<int> alloc_swap_prop2(dpct::get_default_queue());
+
+    //Should allocate and construct N1 int{}
+    dpct::device_vector<int, AllocWithSwapPropagation<int>> D5(std::move(D4), alloc_swap_prop1);
+    if (!verify(D5, N1, V1))
+    {
+        std::cout << "Failed move of default allocator to AllocWithSwapProp" << std::endl;
+        return 1;
+    }
+
+    //Should allocate and construct N2 int{}
+    dpct::device_vector<int, AllocWithSwapPropagation<int>> D6(N2, V2, alloc_swap_prop2);
+    //since there is no swap propagation, we only destroy the excess
+    D6.swap(D5);
+    if (!verify(D6, N1, V1) || !verify(D5, N2, V2))
+    {
+        std::cout << "Failed swap of AllocWithSwapProp" << std::endl;
+        return 1;
+    }
+
+    if (num_constructed_prop != 10 && num_destroyed_prop != 0)
+    {
+        std::cout << "Allocator with swap propagation is swaping incorrectly: [" << num_constructed_prop << ", "
+                  << num_destroyed_prop << "]" << std::endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Test improvements for `dpct::device_vector`, after changes in https://github.com/oneapi-src/SYCLomatic/pull/884 to make it an  [AllocatorAwareContainer](https://en.cppreference.com/w/cpp/named_req/AllocatorAwareContainer).  

Adds check for inserting iterator host data into vector, and for custom allocator definition.  Shows example of usage of custom allocator.