### PR TITLE
[SYCLomatic] Test merge_by_key with double type on device

### DIFF
--- a/features/feature_case/thrust/thrust-merge_by_key.cu
+++ b/features/feature_case/thrust/thrust-merge_by_key.cu
@@ -300,7 +300,8 @@ int main() {
       !test_device<int,char>()      ||
       !test_device<long,long>()      ||
       !test_device<long long,long long>() ||
-      !test_device<float,int>())
+      !test_device<float,int>() ||
+      !test_host<double,double>())
     return EXIT_FAILURE;  
     
   return EXIT_SUCCESS;


### PR DESCRIPTION
Test merge_by_key with device vector of double type.