### PR TITLE
[SYCLomatic] Fix and restore onedpl_test_transform

### DIFF
--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -121,6 +121,7 @@
     <test testName="onedpl_test_stable_partition" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_tabulate" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_transform_if" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="onedpl_test_transform" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_transform_reduce" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />
     <test testName="onedpl_test_translate_key" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />
     <test testName="onedpl_test_uninitialized_fill" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />

--- a/help_function/src/onedpl_test_transform.cpp
+++ b/help_function/src/onedpl_test_transform.cpp
@@ -254,9 +254,9 @@ void transform_call6(Policy policy, Iterator1 first1, Iterator1 last1, Iterator2
         policy, first1, last1, first2,
         oneapi::dpl::make_zip_iterator
         (
-            perm_input1, perm_input2,
-            oneapi::dpl::make_permutation_iterator(perm_input1, perm_map_input),
-            oneapi::dpl::make_permutation_iterator(perm_input2, perm_map_input)
+            perm_input1, perm_input2
+            //oneapi::dpl::make_permutation_iterator(perm_input1, perm_map_input),
+            //oneapi::dpl::make_permutation_iterator(perm_input2, perm_map_input)
         ),
         add_to_tuple_components2<TupleT>()
     );

--- a/help_function/src/onedpl_test_transform.cpp
+++ b/help_function/src/onedpl_test_transform.cpp
@@ -102,6 +102,22 @@ template<typename Queue, typename Array> void device_to_host(Queue &q, Array hos
     q.wait();
 }
 
+// Ported from oneDPL: oneapi/dpl/pstl/tuple_impl.h
+template <typename T>
+struct tuple_decay
+{
+    using type = ::std::decay_t<T>;
+};
+
+template <typename... Args>
+struct tuple_decay<oneapi::dpl::__internal::tuple<Args...>>
+{
+    using type = oneapi::dpl::__internal::tuple<::std::decay_t<Args>...>;
+};
+
+template <typename... Args>
+using tuple_decay_t = typename tuple_decay<Args...>::type;
+
 struct add_tuple_components {
     template <typename Scalar, typename Tuple>
     Scalar operator()(const Scalar& s, const Tuple& t) const {
@@ -178,7 +194,7 @@ struct tuple_square {
        // The generic workaround of the tuple element constness
        // is an internal oneDPL utility class that decays elements
        // within a tuple to deduce the correct return type.
-       using ret_type = oneapi::dpl::__internal::__decay_with_tuple_specialization_t<T>;
+       using ret_type = tuple_decay_t<T>;
        ret_type ret = t;
        std::get<1>(ret) = std::get<0>(ret) * std::get<0>(ret);
        return ret;

--- a/help_function/src/onedpl_test_transform.cpp
+++ b/help_function/src/onedpl_test_transform.cpp
@@ -1532,11 +1532,17 @@ int main() {
         {
             test_name = "transform with make_perm_it 3/8";
             auto src1 = src1_it.get_buffer().template get_access<sycl::access::mode::read>();
+            int expected_transformations[] = { 45, 60, 35, 26 };
             for (int i = 0; i != 8; ++i) {
-                std::cout << src1[i] << " ";
-                std::cout << hostArray[i] << std::endl;
+                if (i < 3 || i > 6) {
+                    num_failing += ASSERT_EQUAL(test_name, src1[i], i);
+                    num_failing += ASSERT_EQUAL(test_name, hostArray[i], i);
+                }
+                else {
+                    num_failing += ASSERT_EQUAL(test_name, src1[i], expected_transformations[i - 3]);
+                    num_failing += ASSERT_EQUAL(test_name, hostArray[i], expected_transformations[i - 3]);
+                }
             }
-
             failed_tests += test_passed(num_failing, test_name);
             num_failing = 0;
         }


### PR DESCRIPTION
This PR fixes the correctness and memory issues encountered in `onedpl_test_transform`. Additionally, several of the previously commented tests (due to issues of iterator composition in oneDPL) have been reenabled. The several remaining excluded tests are documented at the top of the test driver with disable macros and do not affect correctness. These can be included in the future once the remaining iterator composition issues in oneDPL are resolved.

The following issues have been resolved in the test:
* Out-of-bounds memory accesses
* In-place tests where the output begin iterator does not align with either input begin iterator (this violates a constraint in the C++ standard)
* Tests that had only been partially removed (the transform call itself was commented but the correctness check was still performed)
* Integer signedness in tests that produce negative values
* Correctness of expected values in some tests