### PR TITLE
[SYCLomatic] Skip cuda-8.0 to test system_atomic as atomicSub_system is not supported in cuda-8.0

### DIFF
--- a/features/config/TEMPLATE_system_atomic.xml
+++ b/features/config/TEMPLATE_system_atomic.xml
@@ -5,5 +5,8 @@
     <files>
         <file path="feature_case/system_atomic/${testName}.cu" />
     </files>
-    <rules />
+    <rules>
+      <platformRule OSFamily="Linux" kit="CUDA9.0" kitRange="OLDER" runOnThisPlatform="false"/>
+      <platformRule OSFamily="Windows" kit="CUDA9.0" kitRange="OLDER" runOnThisPlatform="false"/>
+    </rules>
 </test>


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>