### PR TITLE
[SYCLomatic #1165] Add malloc, free, and temporary allocation tests

### DIFF
--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -99,6 +99,7 @@
     <test testName="onedpl_test_for_each" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_inner_product" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_histogram" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="onedpl_test_malloc_free" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_max_element" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_maximum" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <!--<test testName="onedpl_test_merge_by_key" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" /> -->
@@ -125,6 +126,7 @@
     <test testName="onedpl_test_stable_partition_copy" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_stable_partition" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_tabulate" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="onedpl_test_temporary_allocation" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_transform_if" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_transform" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_transform_reduce" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />

--- a/help_function/src/onedpl_test_malloc_free.cpp
+++ b/help_function/src/onedpl_test_malloc_free.cpp
@@ -1,0 +1,212 @@
+// ====------ onedpl_test_malloc_free.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/execution"
+#include "oneapi/dpl/iterator"
+
+#include "dpct/dpct.hpp"
+#include "dpct/dpl_utils.hpp"
+
+#include <iostream>
+
+#include <sycl/sycl.hpp>
+
+#include <sys/resource.h>
+
+template <typename String, typename _T1, typename _T2>
+int ASSERT_EQUAL(String msg, _T1 &&X, _T2 &&Y) {
+  if (X != Y) {
+    std::cout << "FAIL: " << msg << " - (" << X << "," << Y << ")" << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+int test_passed(int failing_elems, std::string test_name) {
+  if (failing_elems == 0) {
+    std::cout << "PASS: " << test_name << std::endl;
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+
+  // used to detect failures
+  int failed_tests = 0;
+  int num_failing = 0;
+
+  // Test One, test normal calls for dpct::malloc and dpct::free by allocating a
+  // certain number of bytes on device.
+  {
+    std::size_t num_elements = 5;
+    dpct::device_sys_tag device_exec;
+    dpct::tagged_pointer<dpct::device_sys_tag, void> double_ptr =
+        dpct::malloc(device_exec, num_elements * sizeof(double));
+    double num_data[] = {0.0, 1.0, 2.0, 3.0, 4.0};
+
+    dpct::get_default_queue().submit([&](sycl::handler &h) {
+      h.memcpy(double_ptr, &num_data, sizeof(double) * num_elements);
+    });
+    dpct::get_default_queue().wait();
+
+    dpct::get_default_queue().submit([&](sycl::handler &h) {
+      h.memcpy(&num_data, double_ptr, num_elements * sizeof(double));
+    });
+    dpct::get_default_queue().wait();
+
+    std::string test_name =
+        "malloc and free byte array allocation - device memory with tag";
+    for (std::size_t i = 0; i != num_elements; ++i)
+      failed_tests +=
+          ASSERT_EQUAL(test_name, num_data[i], static_cast<double>(i));
+
+    test_passed(failed_tests, test_name);
+
+    dpct::free(device_exec, double_ptr);
+  }
+
+  // Test Two, test normal calls for dpct::malloc and dpct::free by allocating a
+  // certain number of bytes on host.
+  {
+    std::size_t num_elements = 5;
+    dpct::host_sys_tag host_exec;
+    dpct::tagged_pointer<dpct::host_sys_tag, void> double_ptr =
+        dpct::malloc(host_exec, num_elements * sizeof(double));
+    double num_data[] = {0.0, 1.0, 2.0, 3.0, 4.0};
+
+    ::std::memcpy(double_ptr, &num_data, num_elements * sizeof(double));
+
+    std::string test_name =
+        "malloc and free byte array allocation - host memory with tag";
+    for (std::size_t i = 0; i != num_elements; ++i)
+      failed_tests +=
+          ASSERT_EQUAL(test_name, static_cast<double *>(double_ptr)[i],
+                       static_cast<double>(i));
+    test_passed(failed_tests, test_name);
+
+    dpct::free(host_exec, double_ptr);
+  }
+
+  // Test three, dpct::malloc and dpct::free allocation for a certain number of
+  // int64_t elements on device
+  {
+    std::size_t num_elements = 10;
+    dpct::device_sys_tag device_exec;
+    dpct::tagged_pointer<dpct::device_sys_tag, int64_t> int64_ptr =
+        dpct::malloc<int64_t>(device_exec, num_elements);
+    int64_t num_data[10];
+    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
+
+    dpct::get_default_queue().submit([&](sycl::handler &h) {
+      h.memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
+    });
+    dpct::get_default_queue().wait();
+
+    dpct::get_default_queue().submit([&](sycl::handler &h) {
+      h.memcpy(&num_data, int64_ptr, num_elements * sizeof(int64_t));
+    });
+    dpct::get_default_queue().wait();
+
+    std::string test_name =
+        "malloc and free int64_t array allocation - device memory with tag";
+    for (std::size_t i = 0; i != num_elements; ++i)
+      failed_tests += ASSERT_EQUAL(test_name, num_data[i],
+                                   static_cast<int64_t>(num_elements - i));
+
+    test_passed(failed_tests, test_name);
+
+    dpct::free(device_exec, int64_ptr);
+  }
+
+  // Test four, dpct::malloc and dpct::free allocation for a certain number of
+  // int64_t elements on host
+  {
+    std::size_t num_elements = 10;
+    dpct::host_sys_tag host_exec;
+    dpct::tagged_pointer<dpct::host_sys_tag, int64_t> int64_ptr =
+        dpct::malloc<int64_t>(host_exec, num_elements);
+    int64_t num_data[10];
+    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
+
+    ::std::memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
+
+    std::string test_name =
+        "malloc and free int64_t array allocation - host memory with tag";
+    for (std::size_t i = 0; i != num_elements; ++i)
+      failed_tests += ASSERT_EQUAL(test_name, int64_ptr[i],
+                                   static_cast<int64_t>(num_elements - i));
+
+    test_passed(failed_tests, test_name);
+
+    dpct::free(host_exec, int64_ptr);
+  }
+
+  // Test five, dpct::malloc and dpct::free allocation for a certain number of
+  // int64_t elements on device. oneDPL device policy passed as location
+  {
+    std::size_t num_elements = 10;
+    auto policy = oneapi::dpl::execution::dpcpp_default;
+    dpct::tagged_pointer<dpct::device_sys_tag, int64_t> int64_ptr =
+        dpct::malloc<int64_t>(policy, num_elements);
+    int64_t num_data[10];
+    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
+
+    dpct::get_default_queue().submit([&](sycl::handler &h) {
+      h.memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
+    });
+    dpct::get_default_queue().wait();
+
+    dpct::get_default_queue().submit([&](sycl::handler &h) {
+      h.memcpy(&num_data, int64_ptr, num_elements * sizeof(int64_t));
+    });
+    dpct::get_default_queue().wait();
+
+    std::string test_name =
+        "malloc and free int64_t array allocation - device memory with policy";
+    for (std::size_t i = 0; i != num_elements; ++i)
+      failed_tests += ASSERT_EQUAL(test_name, num_data[i],
+                                   static_cast<int64_t>(num_elements - i));
+
+    test_passed(failed_tests, test_name);
+
+    dpct::free(policy, int64_ptr);
+  }
+
+  // Test six, dpct::malloc and dpct::free allocation for a certain number of
+  // int64_t elements on device. oneDPL host policy passed as location
+  {
+    std::size_t num_elements = 10;
+    auto policy = oneapi::dpl::execution::seq;
+    dpct::tagged_pointer<dpct::host_sys_tag, int64_t> int64_ptr =
+        dpct::malloc<int64_t>(policy, num_elements);
+    int64_t num_data[10];
+    ::std::iota(std::rbegin(num_data), std::rend(num_data), 1);
+
+    ::std::memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
+
+    std::string test_name =
+        "malloc and free int64_t array allocation - host memory with policy";
+    for (std::size_t i = 0; i != num_elements; ++i)
+      failed_tests += ASSERT_EQUAL(test_name, int64_ptr[i],
+                                   static_cast<int64_t>(num_elements - i));
+
+    test_passed(failed_tests, test_name);
+
+    dpct::free(policy, int64_ptr);
+  }
+
+  std::cout << std::endl
+            << failed_tests << " failing test(s) detected." << std::endl;
+  if (failed_tests == 0) {
+    return 0;
+  }
+  return 1;
+}

--- a/help_function/src/onedpl_test_malloc_free.cpp
+++ b/help_function/src/onedpl_test_malloc_free.cpp
@@ -203,6 +203,20 @@ int main() {
     dpct::free(policy, int64_ptr);
   }
 
+  // Test seven, ensure functionality of dpct::internal::malloc_base internal
+  // utility.
+  {
+    std::size_t num_bytes = sizeof(int64_t) * 10;
+    int64_t *ptr = static_cast<int64_t *>(
+        dpct::internal::malloc_base(dpct::host_sys_tag{}, num_bytes));
+    std::iota(ptr, ptr + 10, 0);
+    std::string test_name = "internal::malloc_base utility with host tag";
+
+    for (int i = 0; i < 10; ++i)
+      failed_tests += ASSERT_EQUAL(test_name, ptr[i], i);
+    std::free(ptr);
+  }
+
   std::cout << std::endl
             << failed_tests << " failing test(s) detected." << std::endl;
   if (failed_tests == 0) {

--- a/help_function/src/onedpl_test_temporary_allocation.cpp
+++ b/help_function/src/onedpl_test_temporary_allocation.cpp
@@ -10,16 +10,11 @@
 
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/execution"
-#include "oneapi/dpl/iterator"
 
 #include "dpct/dpct.hpp"
 #include "dpct/dpl_utils.hpp"
 
 #include <iostream>
-
-#include <sycl/sycl.hpp>
-
-#include <sys/resource.h>
 
 template <typename String, typename _T1, typename _T2>
 int ASSERT_EQUAL(String msg, _T1 &&X, _T2 &&Y) {
@@ -38,113 +33,106 @@ int test_passed(int failing_elems, std::string test_name) {
   return 1;
 }
 
+template <typename T, typename PolicyOrTag>
+int test_temporary_allocation_on_device(sycl::queue q,
+                                        PolicyOrTag policy_or_tag,
+                                        std::string test_name,
+                                        std::size_t num_elements) {
+  int failed_tests = 0;
+  // TODO: Use structured bindings when we switch to C++20 and can capture the
+  // variables in lambda capture clause.
+  auto ret_tup = dpct::get_temporary_allocation<T>(policy_or_tag, num_elements);
+  auto ptr = std::get<0>(ret_tup);
+  auto num_allocated = std::get<1>(ret_tup);
+  std::vector<T> num_data(num_elements);
+  std::iota(num_data.begin(), num_data.end(), 0);
+  std::vector<T> out_num_data(num_elements);
+  q.submit([&](sycl::handler &h) {
+     h.memcpy(ptr, num_data.data(), sizeof(T) * num_elements);
+   })
+      .wait();
+  for (std::size_t i = 0; i != num_elements; ++i) {
+    failed_tests += ASSERT_EQUAL(test_name, ptr[i], static_cast<T>(i));
+  }
+  q.submit([&](sycl::handler &h) {
+     h.memcpy(out_num_data.data(), ptr, num_elements * sizeof(T));
+   })
+      .wait();
+  for (std::size_t i = 0; i != num_elements; ++i)
+    failed_tests += ASSERT_EQUAL(test_name, out_num_data[i], static_cast<T>(i));
+
+  failed_tests += (num_allocated != num_elements);
+  test_passed(failed_tests, test_name);
+  dpct::release_temporary_allocation(policy_or_tag, ptr);
+
+  return failed_tests;
+}
+
+template <typename T, typename PolicyOrTag>
+int test_temporary_allocation_on_host(PolicyOrTag policy_or_tag,
+                                      std::string test_name,
+                                      std::size_t num_elements) {
+  int failed_tests = 0;
+  // TODO: Use structured bindings when we switch to C++20 and can capture the
+  // variables in lambda capture clause.
+  auto ret_tup = dpct::get_temporary_allocation<T>(policy_or_tag, num_elements);
+  auto ptr = std::get<0>(ret_tup);
+  auto num_allocated = std::get<1>(ret_tup);
+  std::vector<T> num_data(num_elements);
+  std::iota(num_data.begin(), num_data.end(), 0);
+  std::vector<T> out_num_data(num_elements);
+  ::std::memcpy(ptr, num_data.data(), num_elements * sizeof(T));
+  for (std::size_t i = 0; i != num_elements; ++i)
+    failed_tests += ASSERT_EQUAL(test_name, ptr[i], static_cast<T>(i));
+  ::std::memcpy(out_num_data.data(), ptr, num_elements * sizeof(T));
+  for (std::size_t i = 0; i != num_elements; ++i)
+    failed_tests += ASSERT_EQUAL(test_name, ptr[i], static_cast<T>(i));
+
+  failed_tests += (num_allocated != num_elements);
+  test_passed(failed_tests, test_name);
+  dpct::release_temporary_allocation(policy_or_tag, ptr);
+
+  return failed_tests;
+}
+
 int main() {
   // used to detect failures
   int failed_tests = 0;
-  int num_failing = 0;
 
   // Test One, temporary allocation with device tag.
   {
-    std::size_t num_elements = 10;
     dpct::device_sys_tag device_sys;
-    auto [int64_ptr, elements_allocated] =
-        dpct::get_temporary_allocation<int64_t>(device_sys, num_elements);
-    int64_t num_data[10];
-    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
-
-    dpct::get_default_queue().submit([&](sycl::handler &h) {
-      h.memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
-    });
-    dpct::get_default_queue().wait();
-
-    dpct::get_default_queue().submit([&](sycl::handler &h) {
-      h.memcpy(&num_data, int64_ptr, num_elements * sizeof(int64_t));
-    });
-    dpct::get_default_queue().wait();
-
     std::string test_name =
         "get and release temporary allocation - device memory with tag";
-    failed_tests += ASSERT_EQUAL(test_name, elements_allocated, num_elements);
-    for (std::size_t i = 0; i != num_elements; ++i)
-      failed_tests += ASSERT_EQUAL(test_name, num_data[i],
-                                   static_cast<int64_t>(num_elements - i));
-
-    test_passed(failed_tests, test_name);
-    dpct::release_temporary_allocation(device_sys, int64_ptr);
+    failed_tests += test_temporary_allocation_on_device<int64_t>(
+        dpct::get_default_queue(), device_sys, test_name, 10);
   }
 
   // Test Two, temporary allocation with host tag.
   {
-    std::size_t num_elements = 10;
     dpct::host_sys_tag host_sys;
-    auto [int64_ptr, elements_allocated] =
-        dpct::get_temporary_allocation<int64_t>(host_sys, num_elements);
-    int64_t num_data[10];
-    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
-
-    ::std::memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
-
     std::string test_name =
         "get and release temporary allocation - host memory with tag";
-    failed_tests += ASSERT_EQUAL(test_name, elements_allocated, num_elements);
-    for (std::size_t i = 0; i != num_elements; ++i)
-      failed_tests += ASSERT_EQUAL(test_name, int64_ptr[i],
-                                   static_cast<int64_t>(num_elements - i));
-
-    test_passed(failed_tests, test_name);
-    dpct::release_temporary_allocation(host_sys, int64_ptr);
+    failed_tests +=
+        test_temporary_allocation_on_host<int64_t>(host_sys, test_name, 10);
   }
 
   // Test Three, temporary allocation with device policy.
   {
-    std::size_t num_elements = 10;
-    auto policy = oneapi::dpl::execution::dpcpp_default;
-    auto [int64_ptr, elements_allocated] =
-        dpct::get_temporary_allocation<int64_t>(policy, num_elements);
-    int64_t num_data[10];
-    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
-
-    dpct::get_default_queue().submit([&](sycl::handler &h) {
-      h.memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
-    });
-    dpct::get_default_queue().wait();
-
-    dpct::get_default_queue().submit([&](sycl::handler &h) {
-      h.memcpy(&num_data, int64_ptr, num_elements * sizeof(int64_t));
-    });
-    dpct::get_default_queue().wait();
-
+    sycl::queue q = dpct::get_default_queue();
+    auto policy = oneapi::dpl::execution::make_device_policy(q);
     std::string test_name =
         "get and release temporary allocation - device memory with policy";
-    failed_tests += ASSERT_EQUAL(test_name, elements_allocated, num_elements);
-    for (std::size_t i = 0; i != num_elements; ++i)
-      failed_tests += ASSERT_EQUAL(test_name, num_data[i],
-                                   static_cast<int64_t>(num_elements - i));
-
-    test_passed(failed_tests, test_name);
-    dpct::release_temporary_allocation(policy, int64_ptr);
+    failed_tests +=
+        test_temporary_allocation_on_device<int64_t>(q, policy, test_name, 10);
   }
 
   // Test Four, temporary allocation with host policy.
   {
-    std::size_t num_elements = 10;
-    auto policy = oneapi::dpl::execution::seq;
-    auto [int64_ptr, elements_allocated] =
-        dpct::get_temporary_allocation<int64_t>(policy, num_elements);
-    int64_t num_data[10];
-    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
-
-    ::std::memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
-
     std::string test_name =
         "get and release temporary allocation - host memory with policy";
-    failed_tests += ASSERT_EQUAL(test_name, elements_allocated, num_elements);
-    for (std::size_t i = 0; i != num_elements; ++i)
-      failed_tests += ASSERT_EQUAL(test_name, int64_ptr[i],
-                                   static_cast<int64_t>(num_elements - i));
-
-    test_passed(failed_tests, test_name);
-    dpct::release_temporary_allocation(policy, int64_ptr);
+    failed_tests += test_temporary_allocation_on_host<int64_t>(
+        oneapi::dpl::execution::par_unseq, test_name, 10);
   }
 
   std::cout << std::endl

--- a/help_function/src/onedpl_test_temporary_allocation.cpp
+++ b/help_function/src/onedpl_test_temporary_allocation.cpp
@@ -1,0 +1,156 @@
+// ====------ onedpl_test_temporary_allocation.cpp---------- -*- C++ -*
+// ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/execution"
+#include "oneapi/dpl/iterator"
+
+#include "dpct/dpct.hpp"
+#include "dpct/dpl_utils.hpp"
+
+#include <iostream>
+
+#include <sycl/sycl.hpp>
+
+#include <sys/resource.h>
+
+template <typename String, typename _T1, typename _T2>
+int ASSERT_EQUAL(String msg, _T1 &&X, _T2 &&Y) {
+  if (X != Y) {
+    std::cout << "FAIL: " << msg << " - (" << X << "," << Y << ")" << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+int test_passed(int failing_elems, std::string test_name) {
+  if (failing_elems == 0) {
+    std::cout << "PASS: " << test_name << std::endl;
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+  // used to detect failures
+  int failed_tests = 0;
+  int num_failing = 0;
+
+  // Test One, temporary allocation with device tag.
+  {
+    std::size_t num_elements = 10;
+    dpct::device_sys_tag device_sys;
+    auto [int64_ptr, elements_allocated] =
+        dpct::get_temporary_allocation<int64_t>(device_sys, num_elements);
+    int64_t num_data[10];
+    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
+
+    dpct::get_default_queue().submit([&](sycl::handler &h) {
+      h.memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
+    });
+    dpct::get_default_queue().wait();
+
+    dpct::get_default_queue().submit([&](sycl::handler &h) {
+      h.memcpy(&num_data, int64_ptr, num_elements * sizeof(int64_t));
+    });
+    dpct::get_default_queue().wait();
+
+    std::string test_name =
+        "get and release temporary allocation - device memory with tag";
+    failed_tests += ASSERT_EQUAL(test_name, elements_allocated, num_elements);
+    for (std::size_t i = 0; i != num_elements; ++i)
+      failed_tests += ASSERT_EQUAL(test_name, num_data[i],
+                                   static_cast<int64_t>(num_elements - i));
+
+    test_passed(failed_tests, test_name);
+    dpct::release_temporary_allocation(device_sys, int64_ptr);
+  }
+
+  // Test Two, temporary allocation with host tag.
+  {
+    std::size_t num_elements = 10;
+    dpct::host_sys_tag host_sys;
+    auto [int64_ptr, elements_allocated] =
+        dpct::get_temporary_allocation<int64_t>(host_sys, num_elements);
+    int64_t num_data[10];
+    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
+
+    ::std::memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
+
+    std::string test_name =
+        "get and release temporary allocation - host memory with tag";
+    failed_tests += ASSERT_EQUAL(test_name, elements_allocated, num_elements);
+    for (std::size_t i = 0; i != num_elements; ++i)
+      failed_tests += ASSERT_EQUAL(test_name, int64_ptr[i],
+                                   static_cast<int64_t>(num_elements - i));
+
+    test_passed(failed_tests, test_name);
+    dpct::release_temporary_allocation(host_sys, int64_ptr);
+  }
+
+  // Test Three, temporary allocation with device policy.
+  {
+    std::size_t num_elements = 10;
+    auto policy = oneapi::dpl::execution::dpcpp_default;
+    auto [int64_ptr, elements_allocated] =
+        dpct::get_temporary_allocation<int64_t>(policy, num_elements);
+    int64_t num_data[10];
+    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
+
+    dpct::get_default_queue().submit([&](sycl::handler &h) {
+      h.memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
+    });
+    dpct::get_default_queue().wait();
+
+    dpct::get_default_queue().submit([&](sycl::handler &h) {
+      h.memcpy(&num_data, int64_ptr, num_elements * sizeof(int64_t));
+    });
+    dpct::get_default_queue().wait();
+
+    std::string test_name =
+        "get and release temporary allocation - device memory with policy";
+    failed_tests += ASSERT_EQUAL(test_name, elements_allocated, num_elements);
+    for (std::size_t i = 0; i != num_elements; ++i)
+      failed_tests += ASSERT_EQUAL(test_name, num_data[i],
+                                   static_cast<int64_t>(num_elements - i));
+
+    test_passed(failed_tests, test_name);
+    dpct::release_temporary_allocation(policy, int64_ptr);
+  }
+
+  // Test Four, temporary allocation with host policy.
+  {
+    std::size_t num_elements = 10;
+    auto policy = oneapi::dpl::execution::seq;
+    auto [int64_ptr, elements_allocated] =
+        dpct::get_temporary_allocation<int64_t>(policy, num_elements);
+    int64_t num_data[10];
+    std::iota(std::rbegin(num_data), std::rend(num_data), 1);
+
+    ::std::memcpy(int64_ptr, &num_data, sizeof(int64_t) * num_elements);
+
+    std::string test_name =
+        "get and release temporary allocation - host memory with policy";
+    failed_tests += ASSERT_EQUAL(test_name, elements_allocated, num_elements);
+    for (std::size_t i = 0; i != num_elements; ++i)
+      failed_tests += ASSERT_EQUAL(test_name, int64_ptr[i],
+                                   static_cast<int64_t>(num_elements - i));
+
+    test_passed(failed_tests, test_name);
+    dpct::release_temporary_allocation(policy, int64_ptr);
+  }
+
+  std::cout << std::endl
+            << failed_tests << " failing test(s) detected." << std::endl;
+  if (failed_tests == 0) {
+    return 0;
+  }
+  return 1;
+}


### PR DESCRIPTION
This PR adds test cases for `malloc`, `free`, and temporary allocations APIs that are added in https://github.com/oneapi-src/SYCLomatic/pull/1165.

We test host and device allocation / freeing with execution policies and system tags.