### PR TITLE
[SYCLomatic #1165] Add test for tagged_pointer

### DIFF
--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -126,6 +126,7 @@
     <test testName="onedpl_test_stable_partition_copy" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_stable_partition" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_tabulate" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="onedpl_test_tagged_pointer" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_temporary_allocation" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_transform_if" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_transform" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />

--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -125,6 +125,7 @@
     <test testName="onedpl_test_segmented_sort_keys" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_stable_partition_copy" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_stable_partition" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="onedpl_test_sys_tag_utils" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_tabulate" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_tagged_pointer" configFile="config/TEMPLATE_help_function_usm.xml" />
     <test testName="onedpl_test_temporary_allocation" configFile="config/TEMPLATE_help_function_usm.xml" />

--- a/help_function/src/onedpl_test_sys_tag_utils.cpp
+++ b/help_function/src/onedpl_test_sys_tag_utils.cpp
@@ -1,0 +1,115 @@
+// ====------ onedpl_test_sys_tag_utils.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <oneapi/dpl/execution>
+
+#include "dpct/dpct.hpp"
+#include "dpct/dpl_utils.hpp"
+
+#include <iostream>
+
+template <typename String, typename _T1, typename _T2>
+int ASSERT_EQUAL(String msg, _T1 &&X, _T2 &&Y) {
+  if (X != Y) {
+    std::cout << "FAIL: " << msg << " - (" << X << "," << Y << ")" << std::endl;
+    return 1;
+  } else {
+    std::cout << "PASS: " << msg << std::endl;
+    return 0;
+  }
+}
+
+int test_internal_policy_conversion(void) {
+  int num_fails = 0;
+
+  using seq_tag = dpct::internal::policy_or_tag_to_tag<decltype(
+      oneapi::dpl::execution::seq)>::type;
+  using unseq_tag = dpct::internal::policy_or_tag_to_tag_t<decltype(
+      oneapi::dpl::execution::seq)>;
+  using par_tag = dpct::internal::policy_or_tag_to_tag_t<decltype(
+      oneapi::dpl::execution::par)>;
+  using par_unseq_tag = dpct::internal::policy_or_tag_to_tag_t<decltype(
+      oneapi::dpl::execution::par_unseq)>;
+  using dev_tag = dpct::internal::policy_or_tag_to_tag_t<decltype(
+      oneapi::dpl::execution::dpcpp_default)>;
+  using reflect_host_tag =
+      dpct::internal::policy_or_tag_to_tag_t<dpct::host_sys_tag>;
+  using reflect_dev_tag =
+      dpct::internal::policy_or_tag_to_tag_t<dpct::device_sys_tag>;
+
+  num_fails += ASSERT_EQUAL("seq policy tag conversion",
+                            std::is_same_v<seq_tag, dpct::host_sys_tag>, true);
+  num_fails +=
+      ASSERT_EQUAL("unseq policy tag conversion",
+                   std::is_same_v<unseq_tag, dpct::host_sys_tag>, true);
+  num_fails += ASSERT_EQUAL("par policy tag conversion",
+                            std::is_same_v<par_tag, dpct::host_sys_tag>, true);
+  num_fails +=
+      ASSERT_EQUAL("par_unseq policy tag conversion",
+                   std::is_same_v<par_unseq_tag, dpct::host_sys_tag>, true);
+  num_fails +=
+      ASSERT_EQUAL("dpcpp_default policy tag conversion",
+                   std::is_same_v<dev_tag, dpct::device_sys_tag>, true);
+  num_fails +=
+      ASSERT_EQUAL("host tag reflection",
+                   std::is_same_v<reflect_host_tag, dpct::host_sys_tag>, true);
+  num_fails +=
+      ASSERT_EQUAL("device tag reflection",
+                   std::is_same_v<reflect_dev_tag, dpct::device_sys_tag>, true);
+
+  return num_fails;
+}
+
+int test_internal_is_host_policy_or_tag(void) {
+  int num_fails = 0;
+
+  constexpr bool seq_is_host_tag =
+      dpct::internal::is_host_policy_or_tag<decltype(
+          oneapi::dpl::execution::seq)>::value;
+  constexpr bool unseq_is_host_tag =
+      dpct::internal::is_host_policy_or_tag_v<decltype(
+          oneapi::dpl::execution::unseq)>;
+  constexpr bool par_is_host_tag =
+      dpct::internal::is_host_policy_or_tag_v<decltype(
+          oneapi::dpl::execution::par)>;
+  constexpr bool par_unseq_is_host_tag =
+      dpct::internal::is_host_policy_or_tag_v<decltype(
+          oneapi::dpl::execution::par)>;
+  constexpr bool dev_is_host_tag =
+      dpct::internal::is_host_policy_or_tag_v<decltype(
+          oneapi::dpl::execution::dpcpp_default)>;
+  constexpr bool host_tag_is_host_tag =
+      dpct::internal::is_host_policy_or_tag_v<dpct::host_sys_tag>;
+  constexpr bool dev_tag_is_host_tag =
+      dpct::internal::is_host_policy_or_tag_v<dpct::device_sys_tag>;
+
+  num_fails += ASSERT_EQUAL("seq policy is host", seq_is_host_tag, true);
+  num_fails += ASSERT_EQUAL("unseq policy is host", unseq_is_host_tag, true);
+  num_fails += ASSERT_EQUAL("par policy is host", par_is_host_tag, true);
+  num_fails +=
+      ASSERT_EQUAL("par_unseq policy is host", par_unseq_is_host_tag, true);
+  num_fails +=
+      ASSERT_EQUAL("dpcpp_default policy is host", dev_is_host_tag, false);
+  num_fails += ASSERT_EQUAL("host tag is host", host_tag_is_host_tag, true);
+  num_fails += ASSERT_EQUAL("device tag is host", dev_tag_is_host_tag, false);
+
+  return num_fails;
+}
+
+int main() {
+  int failed_tests = test_internal_policy_conversion();
+  failed_tests += test_internal_is_host_policy_or_tag();
+
+  std::cout << std::endl
+            << failed_tests << " failing test(s) detected." << std::endl;
+  if (failed_tests == 0) {
+    return 0;
+  }
+  return 1;
+}

--- a/help_function/src/onedpl_test_tagged_pointer.cpp
+++ b/help_function/src/onedpl_test_tagged_pointer.cpp
@@ -1,0 +1,129 @@
+// ====------ onedpl_test_tagged_pointer.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+// Adapted from onedpl_test_device_ptr.cpp
+
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/iterator>
+#include <oneapi/dpl/numeric>
+
+#include "dpct/dpct.hpp"
+#include "dpct/dpl_utils.hpp"
+
+#include <sycl/sycl.hpp>
+
+#include <iostream>
+
+template <typename String, typename _T1, typename _T2>
+int ASSERT_EQUAL(String msg, _T1 &&X, _T2 &&Y) {
+  if (X != Y) {
+    std::cout << "FAIL: " << msg << " - (" << X << "," << Y << ")" << std::endl;
+    return 1;
+  } else {
+    std::cout << "PASS: " << msg << std::endl;
+    return 0;
+  }
+}
+
+template <typename SystemTag> int test_tagged_pointer_manipulation(void) {
+  int failing_tests = 0;
+  constexpr ::std::size_t n = 20;
+  SystemTag system;
+  ::std::string sys = ::std::is_same_v<dpct::host_sys_tag, SystemTag>
+                          ? "dpct::host_sys_tag"
+                          : "dpct::device_sys_tag";
+  std::string int_ptr_name = "dpct::tagged_pointer<" + sys + ", int>";
+  std::string void_ptr_name = "dpct::tagged_pointer<" + sys + ", void>";
+
+  dpct::tagged_pointer<SystemTag, void> void_ptr_beg =
+      dpct::malloc(system, sizeof(int) * n);
+  dpct::tagged_pointer<SystemTag, int> int_ptr_beg =
+      static_cast<dpct::tagged_pointer<SystemTag, int>>(void_ptr_beg);
+
+  dpct::tagged_pointer<SystemTag, void> void_ptr_beg2 =
+      static_cast<dpct::tagged_pointer<SystemTag, void>>(int_ptr_beg);
+  failing_tests += ASSERT_EQUAL(void_ptr_name + " conversion operator",
+                                void_ptr_beg == void_ptr_beg2, true);
+
+  dpct::tagged_pointer<SystemTag, int> int_ptr_end = int_ptr_beg + n;
+  failing_tests += ASSERT_EQUAL(
+      int_ptr_name + " add operator",
+      static_cast<int *>(int_ptr_end) - static_cast<int *>(int_ptr_beg), n);
+
+  dpct::tagged_pointer<SystemTag, int> expect_beg = int_ptr_end - n;
+  failing_tests += ASSERT_EQUAL(int_ptr_name + " subtract operator",
+                                int_ptr_beg == expect_beg, true);
+
+  failing_tests += ASSERT_EQUAL(int_ptr_name + " difference operator",
+                                int_ptr_end - int_ptr_beg, n);
+
+  expect_beg++;
+  expect_beg--;
+  failing_tests +=
+      ASSERT_EQUAL(int_ptr_name + " postfix increment and decrement",
+                   int_ptr_beg == expect_beg, true);
+
+  ++expect_beg;
+  --expect_beg;
+  failing_tests +=
+      ASSERT_EQUAL(int_ptr_name + " prefix increment and decrement",
+                   int_ptr_beg == expect_beg, true);
+
+  expect_beg += 2;
+  expect_beg -= 2;
+  failing_tests +=
+      ASSERT_EQUAL(int_ptr_name + " addition and subtraction assignment",
+                   int_ptr_beg == expect_beg, true);
+
+  // Test conversion to base pointer
+  int *int_ptr_beg_raw = int_ptr_beg;
+  int *int_ptr_end_raw = int_ptr_end;
+  failing_tests +=
+      ASSERT_EQUAL(int_ptr_name + " tagged_pointer<int> conversion to int*",
+                   int_ptr_end_raw - int_ptr_beg_raw, n);
+
+  dpct::free(system, void_ptr_beg);
+  return failing_tests;
+}
+
+template <typename SystemTag> int test_tagged_pointer_iteration(void) {
+  constexpr ::std::size_t n = 1024;
+  int return_fail_code = 0;
+  SystemTag system;
+  bool is_host = ::std::is_same_v<dpct::host_sys_tag, SystemTag>;
+  ::std::string sys = is_host ? "dpct::host_sys_tag" : "dpct::device_sys_tag";
+  std::string int_ptr_name = "dpct::tagged_pointer<" + sys + ", int>";
+
+  auto policy = oneapi::dpl::execution::dpcpp_default;
+  dpct::tagged_pointer<SystemTag, int> ptr_beg = dpct::malloc<int>(system, n);
+  dpct::tagged_pointer<SystemTag, int> ptr_end = ptr_beg + n;
+
+  std::fill(policy, ptr_beg, ptr_end, 99);
+  int result = oneapi::dpl::reduce(policy, ptr_beg, ptr_beg + n);
+  return_fail_code +=
+      ASSERT_EQUAL(int_ptr_name + " reduce algorithm test", result, n * 99);
+  dpct::free(system, ptr_beg);
+  return return_fail_code;
+}
+
+int main() {
+  int failed_tests = test_tagged_pointer_manipulation<dpct::host_sys_tag>();
+  failed_tests += test_tagged_pointer_manipulation<dpct::device_sys_tag>();
+
+  failed_tests += test_tagged_pointer_iteration<dpct::host_sys_tag>();
+  failed_tests += test_tagged_pointer_iteration<dpct::device_sys_tag>();
+
+  std::cout << std::endl
+            << failed_tests << " failing test(s) detected." << std::endl;
+  if (failed_tests == 0) {
+    return 0;
+  }
+  return 1;
+}

--- a/help_function/src/onedpl_test_tagged_pointer.cpp
+++ b/help_function/src/onedpl_test_tagged_pointer.cpp
@@ -11,13 +11,10 @@
 
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
-#include <oneapi/dpl/iterator>
 #include <oneapi/dpl/numeric>
 
 #include "dpct/dpct.hpp"
 #include "dpct/dpl_utils.hpp"
-
-#include <sycl/sycl.hpp>
 
 #include <iostream>
 
@@ -72,21 +69,32 @@ template <typename SystemTag> int test_tagged_pointer_manipulation(void) {
                                 int_ptr_end - int_ptr_beg, n);
 
   expect_beg++;
+  failing_tests +=
+      ASSERT_EQUAL(int_ptr_name + " postfix increment",
+                   (int_ptr_beg + 1) == expect_beg, true);
+
   expect_beg--;
   failing_tests +=
-      ASSERT_EQUAL(int_ptr_name + " postfix increment and decrement",
+      ASSERT_EQUAL(int_ptr_name + " postfix decrement",
                    int_ptr_beg == expect_beg, true);
 
   ++expect_beg;
+  failing_tests +=
+      ASSERT_EQUAL(int_ptr_name + " prefix increment",
+                   (int_ptr_beg + 1) == expect_beg, true);
   --expect_beg;
   failing_tests +=
-      ASSERT_EQUAL(int_ptr_name + " prefix increment and decrement",
+      ASSERT_EQUAL(int_ptr_name + " prefix decrement",
                    int_ptr_beg == expect_beg, true);
 
   expect_beg += 2;
+  failing_tests +=
+      ASSERT_EQUAL(int_ptr_name + " addition assignment",
+                   (int_ptr_beg + 2) == expect_beg, true);
+
   expect_beg -= 2;
   failing_tests +=
-      ASSERT_EQUAL(int_ptr_name + " addition and subtraction assignment",
+      ASSERT_EQUAL(int_ptr_name + " subtraction assignment",
                    int_ptr_beg == expect_beg, true);
 
   // Test conversion to base pointer
@@ -103,14 +111,11 @@ template <typename SystemTag> int test_tagged_pointer_manipulation(void) {
   failing_tests += ASSERT_EQUAL(int_ptr_name + " subscript operator",
                                 int_ptr_beg[1] == 2, true);
 
-  failing_tests += ASSERT_EQUAL(int_ptr_name + " subscript operator",
-                                int_ptr_beg[1] == 2, true);
-
   dpct::tagged_pointer<SystemTag, integer_wrapper> int_wrapper_beg =
       dpct::malloc<integer_wrapper>(system, 1);
   int_wrapper_beg->val = 5;
   failing_tests += ASSERT_EQUAL(int_wrapper_name + " arrow operator",
-                                int_wrapper_beg->val == 5, true);
+                                (*int_wrapper_beg).val == 5, true);
 
   dpct::free(system, void_ptr_beg);
   dpct::free(system, int_wrapper_beg);


### PR DESCRIPTION
This PR tests the `dpct::tagged_pointer` functionality provided in https://github.com/oneapi-src/SYCLomatic/pull/1165 by performing various pointer arithmetic operations, conversions, and invokes oneDPL algorithms to ensure expected functionality.