### PR TITLE
[SYCLomatic] Skip cuda-8.0, cuda-9.2, cuda10.0 test that thrust operators do not support

### DIFF
--- a/features/config/TEMPLATE_thrust_operator.xml
+++ b/features/config/TEMPLATE_thrust_operator.xml
@@ -6,8 +6,8 @@
         <file path="feature_case/thrust/${testName}.cu" />
     </files>
     <rules>
-        <platformRule OSFamily="Linux" kit="CUDA10.0" kitRange="OLDER" runOnThisPlatform="false"/>
-        <platformRule OSFamily="Windows" kit="CUDA10.0" kitRange="OLDER" runOnThisPlatform="false"/>
+        <platformRule OSFamily="Linux" kit="CUDA10.2" kitRange="OLDER" runOnThisPlatform="false"/>
+        <platformRule OSFamily="Windows" kit="CUDA10.2" kitRange="OLDER" runOnThisPlatform="false"/>
         <optlevelRule excludeOptlevelNameString="cuda_backend" />
     </rules>
 </test>


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>