### PR TITLE
Switching to "lazy" JIT SYCL compilation instead of eager

### DIFF
--- a/test_utils.py
+++ b/test_utils.py
@@ -57,9 +57,9 @@ def set_default_compiler(use_cuda : bool):
         test_config.DPCXX_COM = 'clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda'
         return
     if (platform.system() == 'Windows'):
-        test_config.DPCXX_COM = "icx-cl -fsycl"
+        test_config.DPCXX_COM = "icx-cl -fsycl -fsycl-device-code-split=per_kernel"
     else:
-        test_config.DPCXX_COM = "icpx -fsycl"
+        test_config.DPCXX_COM = "icpx -fsycl -fsycl-device-code-split=per_kernel"
 
 def set_default_c_compiler(use_cuda : bool):
     if (use_cuda):


### PR DESCRIPTION
This switches to "lazy" JIT compilation of SYCL kernels for tests to shrink runtimes.  

We are not worried about benchmarking, but rather correctness.  With eager compilation of kernels, often kernels are compiled which are never used, inflating runtime of tests which is already often dominated with JIT compilation time.

This changes JIT compilation to `per_kernel` which only compiles a kernel when it is encountered at runtime.
https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2023-2/just-in-time-compilation.html

The tradeoffs of this need to be considered fully here before merging as this will change the option for all tests.  It may be nice to instead be able to turn this on for individual tests.
