### PR TITLE
[SYCLomatic] Simplify tests for segmented sort algorithms

### DIFF
--- a/help_function/src/onedpl_test_segmented_sort_keys.cpp
+++ b/help_function/src/onedpl_test_segmented_sort_keys.cpp
@@ -109,7 +109,7 @@ segmented_sort_keys(sycl::queue queue, int64_t nsegments, int64_t nsort,
                      bool use_io_iterator_pair = false, int begin_bit = 0,
                      int end_bit = sizeof(self_ptr) * 8) {
   bool ret = true;
-  if (use_io_iterator_pair && algorithm != 3)
+  if (use_io_iterator_pair && algorithm != 2)
   {
     //only public API can use io_iterator_pair
     return false;

--- a/help_function/src/onedpl_test_segmented_sort_keys.cpp
+++ b/help_function/src/onedpl_test_segmented_sort_keys.cpp
@@ -134,12 +134,7 @@ segmented_sort_keys(sycl::queue queue, int64_t nsegments, int64_t nsort,
         oneapi::dpl::execution::make_device_policy(queue), self_ptr, values_ptr,
         n, nsegments, offset_generator_starts, offset_generator_ends,
         descending, begin_bit, end_bit);
-  } else if (algorithm == 2) {
-    dpct::internal::segmented_sort_keys_by_two_pair_sorts(
-        oneapi::dpl::execution::make_device_policy(queue), self_ptr, values_ptr,
-        n, nsegments, offset_generator_starts, offset_generator_ends,
-        descending, begin_bit, end_bit);
-  } else if (algorithm == 3) // this will be the one used for the mapping,
+  } else if (algorithm == 2) // this will be the one used for the mapping,
                              // others are for timing purposes
   {
     if (use_io_iterator_pair)
@@ -170,8 +165,7 @@ segmented_sort_keys(sycl::queue queue, int64_t nsegments, int64_t nsort,
 // Algorithm:
 //   0: parallel_for of serial sorts
 //   1: for loop of parallel sorts
-//   2: segmented sort with 2 sorts
-//   3: let the device characteristics decide
+//   2: let the device characteristics decide
 template <typename scalar_t>
 int test_with_generated_offsets(const int64_t nsegments, const int64_t nsort,
                                 const int64_t n, const bool descending,
@@ -184,7 +178,7 @@ int test_with_generated_offsets(const int64_t nsegments, const int64_t nsort,
                    << (descending ? "descending" : "ascending") << " order"
                    << ::std::endl;
 
-  if (use_io_iterator_pair && algorithm != 3)
+  if (use_io_iterator_pair && algorithm != 2)
   {
     ::std::cout<<"io_iterator_pair interface only available with public dpct API"<<::std::endl;
     return 1;
@@ -271,8 +265,6 @@ int test_with_generated_offsets(const int64_t nsegments, const int64_t nsort,
   } else if (alg == 1) {
     test_name_stream << "for loop of parallel sorts.";
   } else if (alg == 2) {
-    test_name_stream << "two full pair sorts.";
-  } else if (alg == 3) {
     test_name_stream << "algorithm based on device and data.";
   }
 
@@ -306,11 +298,7 @@ int test_with_device_offsets(bool descending, int algorithm) {
     dpct::internal::segmented_sort_keys_by_parallel_sorts(
         oneapi::dpl::execution::make_device_policy(q), d_keys, d_out_keys,
         num_items, num_segs, d_offsets, d_offsets + 1, descending);
-  } else if (algorithm == 2) {
-    dpct::internal::segmented_sort_keys_by_two_pair_sorts(
-        oneapi::dpl::execution::make_device_policy(q), d_keys, d_out_keys,
-        num_items, num_segs, d_offsets, d_offsets + 1, descending);
-  } else if (algorithm == 3) // this will be the one used for the mapping,
+  } else if (algorithm == 2) // this will be the one used for the mapping,
                              // others are for timing purposes
   {
     dpct::segmented_sort_keys(oneapi::dpl::execution::make_device_policy(q),
@@ -358,7 +346,7 @@ int test_with_device_offsets(bool descending, int algorithm) {
 int main() {
 
   int alg_start = 0;
-  int alg_end = 4;
+  int alg_end = 3;
   int test_suites_failed = 0;
     int64_t nsegments = 100;
     int64_t nsort = 100;

--- a/help_function/src/onedpl_test_segmented_sort_keys.cpp
+++ b/help_function/src/onedpl_test_segmented_sort_keys.cpp
@@ -369,7 +369,7 @@ int main() {
   {
     //test with io_iterator_pair
     int tests_failed = 0;
-    tests_failed += test_with_generated_offsets<float>(nsegments, nsort, n, false, 3, true);
+    tests_failed += test_with_generated_offsets<float>(nsegments, nsort, n, false, 2, true);
   
       test_suites_failed +=
           test_passed(tests_failed, "Test segmented sort with io_iterator_pair");

--- a/help_function/src/onedpl_test_segmented_sort_pairs.cpp
+++ b/help_function/src/onedpl_test_segmented_sort_pairs.cpp
@@ -141,12 +141,7 @@ segmented_sort_pairs(sycl::queue queue, int64_t nsegments, int64_t nsort,
         oneapi::dpl::execution::make_device_policy(queue), self_ptr, values_ptr,
         reverse_indices_ptr, indices_ptr, n, nsegments, offset_generator_starts,
         offset_generator_ends, descending, begin_bit, end_bit);
-  } else if (algorithm == 2) {
-    dpct::internal::segmented_sort_pairs_by_two_pair_sorts(
-        oneapi::dpl::execution::make_device_policy(queue), self_ptr, values_ptr,
-        reverse_indices_ptr, indices_ptr, n, nsegments, offset_generator_starts,
-        offset_generator_ends, descending, begin_bit, end_bit);
-  } else if (algorithm == 3) // this will be the one used for the mapping,
+  } else if (algorithm == 2) // this will be the one used for the mapping,
                              // others are for timing purposes
   {
     if (use_io_iterator_pair)
@@ -305,8 +300,6 @@ int test_with_generated_offsets(const int64_t nsegments, const int64_t nsort,
   } else if (alg == 1) {
     test_name_stream << "for loop of parallel sorts.";
   } else if (alg == 2) {
-    test_name_stream << "two full pair sorts.";
-  } else if (alg == 3) {
     test_name_stream << "algorithm based on device and data.";
   }
 
@@ -346,12 +339,7 @@ int test_with_device_offsets(bool descending, int algorithm) {
         oneapi::dpl::execution::make_device_policy(q), d_keys, d_out_keys,
         d_vals, d_out_vals, num_items, num_segs, d_offsets, d_offsets + 1,
         descending);
-  } else if (algorithm == 2) {
-    dpct::internal::segmented_sort_pairs_by_two_pair_sorts(
-        oneapi::dpl::execution::make_device_policy(q), d_keys, d_out_keys,
-        d_vals, d_out_vals, num_items, num_segs, d_offsets, d_offsets + 1,
-        descending);
-  } else if (algorithm == 3) // this will be the one used for the mapping,
+  } else if (algorithm == 2) // this will be the one used for the mapping,
                              // others are for timing purposes
   {
     dpct::segmented_sort_pairs(oneapi::dpl::execution::make_device_policy(q),
@@ -419,7 +407,7 @@ int test_with_device_offsets(bool descending, int algorithm) {
 int main() {
 
   int alg_start = 0;
-  int alg_end = 4;
+  int alg_end = 3;
   int test_suites_failed = 0;
     int64_t nsegments = 100;
     int64_t nsort = 100;

--- a/help_function/src/onedpl_test_segmented_sort_pairs.cpp
+++ b/help_function/src/onedpl_test_segmented_sort_pairs.cpp
@@ -190,7 +190,7 @@ int test_with_generated_offsets(const int64_t nsegments, const int64_t nsort,
                    << (descending ? "descending" : "ascending") << " order"
                    << std::endl;
 
-  if (use_io_iterator_pair && algorithm != 3)
+  if (use_io_iterator_pair && algorithm != 2)
   {
     std::cout<<"io_iterator_pair interface only available with public dpct API"<<std::endl;
     return 1;
@@ -430,7 +430,7 @@ int main() {
   {
     //test with io_iterator_pair
     int tests_failed = 0;
-    tests_failed += test_with_generated_offsets<float>(nsegments, nsort, n, false, 3, true);
+    tests_failed += test_with_generated_offsets<float>(nsegments, nsort, n, false, 2, true);
   
       test_suites_failed +=
           test_passed(tests_failed, "Test segmented sort with io_iterator_pair");

--- a/help_function/src/onedpl_test_segmented_sort_pairs.cpp
+++ b/help_function/src/onedpl_test_segmented_sort_pairs.cpp
@@ -109,7 +109,7 @@ segmented_sort_pairs(sycl::queue queue, int64_t nsegments, int64_t nsort,
                      bool use_io_iterator_pair = false, int begin_bit = 0,
                      int end_bit = sizeof(self_ptr) * 8) {
   bool ret = true;
-  if (use_io_iterator_pair && algorithm != 3)
+  if (use_io_iterator_pair && algorithm != 2)
   {
     //only public API can use io_iterator_pair
     return ret;


### PR DESCRIPTION
Remove tests for two pair sorts algorithm for segmented sorts.  
This combined with the matching change to SYCLomatic will reduce JIT compilation time significantly.

Must be merged before https://github.com/oneapi-src/SYCLomatic/pull/1347 is merged.