### PR TITLE
[SYCLomatic #1396]  Adjust memory tests to accommodate function signature changes

### DIFF
--- a/help_function/src/onedpl_test_malloc_free.cpp
+++ b/help_function/src/onedpl_test_malloc_free.cpp
@@ -39,7 +39,7 @@ int test_malloc_free_on_device(sycl::queue q, PolicyOrTag policy_or_tag,
                                TestVoidMalloc) {
   using alloc_t = std::conditional_t<TestVoidMalloc::value, void, T>;
   int failed_tests = 0;
-  dpct::tagged_pointer<dpct::device_sys_tag, alloc_t> ptr;
+  dpct::tagged_pointer<alloc_t, dpct::device_sys_tag> ptr;
   if constexpr (TestVoidMalloc::value) {
     ptr = dpct::malloc(policy_or_tag, num_elements * sizeof(T));
   } else {
@@ -76,7 +76,7 @@ template <typename T, typename PolicyOrTag, typename TestVoidMalloc>
 int test_malloc_free_on_host(PolicyOrTag policy_or_tag, std::string test_name,
                              std::size_t num_elements, TestVoidMalloc) {
   using alloc_t = std::conditional_t<TestVoidMalloc::value, void, T>;
-  dpct::tagged_pointer<dpct::host_sys_tag, alloc_t> ptr;
+  dpct::tagged_pointer<alloc_t, dpct::host_sys_tag> ptr;
   if constexpr (TestVoidMalloc::value) {
     ptr = dpct::malloc(policy_or_tag, num_elements * sizeof(T));
   } else {

--- a/help_function/src/onedpl_test_tagged_pointer.cpp
+++ b/help_function/src/onedpl_test_tagged_pointer.cpp
@@ -46,22 +46,22 @@ template <typename SystemTag> int test_tagged_pointer_manipulation(void) {
       "dpct::tagged_pointer<" + sys + ", integer_wrapper>";
   std::string void_ptr_name = "dpct::tagged_pointer<" + sys + ", void>";
 
-  dpct::tagged_pointer<SystemTag, void> void_ptr_beg =
+  dpct::tagged_pointer<void, SystemTag> void_ptr_beg =
       dpct::malloc(system, sizeof(int) * n);
-  dpct::tagged_pointer<SystemTag, int> int_ptr_beg =
-      static_cast<dpct::tagged_pointer<SystemTag, int>>(void_ptr_beg);
+  dpct::tagged_pointer<int, SystemTag> int_ptr_beg =
+      static_cast<dpct::tagged_pointer<int, SystemTag>>(void_ptr_beg);
 
-  dpct::tagged_pointer<SystemTag, void> void_ptr_beg2 =
-      static_cast<dpct::tagged_pointer<SystemTag, void>>(int_ptr_beg);
+  dpct::tagged_pointer<void, SystemTag> void_ptr_beg2 =
+      static_cast<dpct::tagged_pointer<void, SystemTag>>(int_ptr_beg);
   failing_tests += ASSERT_EQUAL(void_ptr_name + " conversion operator",
                                 void_ptr_beg == void_ptr_beg2, true);
 
-  dpct::tagged_pointer<SystemTag, int> int_ptr_end = int_ptr_beg + n;
+  dpct::tagged_pointer<int, SystemTag> int_ptr_end = int_ptr_beg + n;
   failing_tests += ASSERT_EQUAL(
       int_ptr_name + " add operator",
       static_cast<int *>(int_ptr_end) - static_cast<int *>(int_ptr_beg), n);
 
-  dpct::tagged_pointer<SystemTag, int> expect_beg = int_ptr_end - n;
+  dpct::tagged_pointer<int, SystemTag> expect_beg = int_ptr_end - n;
   failing_tests += ASSERT_EQUAL(int_ptr_name + " subtract operator",
                                 int_ptr_beg == expect_beg, true);
 
@@ -105,7 +105,7 @@ template <typename SystemTag> int test_tagged_pointer_manipulation(void) {
   failing_tests += ASSERT_EQUAL(int_ptr_name + " subscript operator",
                                 int_ptr_beg[1] == 2, true);
 
-  dpct::tagged_pointer<SystemTag, integer_wrapper> int_wrapper_beg =
+  dpct::tagged_pointer<integer_wrapper, SystemTag> int_wrapper_beg =
       dpct::malloc<integer_wrapper>(system, 1);
   int_wrapper_beg->val = 5;
   failing_tests += ASSERT_EQUAL(int_wrapper_name + " arrow operator",

--- a/help_function/src/onedpl_test_temporary_allocation.cpp
+++ b/help_function/src/onedpl_test_temporary_allocation.cpp
@@ -63,7 +63,7 @@ int test_temporary_allocation_on_device(sycl::queue q,
 
   failed_tests += (num_allocated != num_elements);
   test_passed(failed_tests, test_name);
-  dpct::release_temporary_allocation(policy_or_tag, ptr, num_elements);
+  dpct::release_temporary_allocation(policy_or_tag, ptr);
 
   return failed_tests;
 }
@@ -90,7 +90,7 @@ int test_temporary_allocation_on_host(PolicyOrTag policy_or_tag,
 
   failed_tests += (num_allocated != num_elements);
   test_passed(failed_tests, test_name);
-  dpct::release_temporary_allocation(policy_or_tag, ptr, num_allocated);
+  dpct::release_temporary_allocation(policy_or_tag, ptr);
 
   return failed_tests;
 }

--- a/help_function/src/onedpl_test_temporary_allocation.cpp
+++ b/help_function/src/onedpl_test_temporary_allocation.cpp
@@ -42,8 +42,8 @@ int test_temporary_allocation_on_device(sycl::queue q,
   // TODO: Use structured bindings when we switch to C++20 and can capture the
   // variables in lambda capture clause.
   auto ret_tup = dpct::get_temporary_allocation<T>(policy_or_tag, num_elements);
-  auto ptr = std::get<0>(ret_tup);
-  auto num_allocated = std::get<1>(ret_tup);
+  auto ptr = ret_tup.first;
+  auto num_allocated = ret_tup.second;
   std::vector<T> num_data(num_elements);
   std::iota(num_data.begin(), num_data.end(), 0);
   std::vector<T> out_num_data(num_elements);
@@ -63,7 +63,7 @@ int test_temporary_allocation_on_device(sycl::queue q,
 
   failed_tests += (num_allocated != num_elements);
   test_passed(failed_tests, test_name);
-  dpct::release_temporary_allocation(policy_or_tag, ptr);
+  dpct::release_temporary_allocation(policy_or_tag, ptr, num_elements);
 
   return failed_tests;
 }
@@ -76,8 +76,8 @@ int test_temporary_allocation_on_host(PolicyOrTag policy_or_tag,
   // TODO: Use structured bindings when we switch to C++20 and can capture the
   // variables in lambda capture clause.
   auto ret_tup = dpct::get_temporary_allocation<T>(policy_or_tag, num_elements);
-  auto ptr = std::get<0>(ret_tup);
-  auto num_allocated = std::get<1>(ret_tup);
+  auto ptr = ret_tup.first;
+  auto num_allocated = ret_tup.second;
   std::vector<T> num_data(num_elements);
   std::iota(num_data.begin(), num_data.end(), 0);
   std::vector<T> out_num_data(num_elements);
@@ -90,7 +90,7 @@ int test_temporary_allocation_on_host(PolicyOrTag policy_or_tag,
 
   failed_tests += (num_allocated != num_elements);
   test_passed(failed_tests, test_name);
-  dpct::release_temporary_allocation(policy_or_tag, ptr);
+  dpct::release_temporary_allocation(policy_or_tag, ptr, num_allocated);
 
   return failed_tests;
 }


### PR DESCRIPTION
[SYCLomatic #1396](https://github.com/oneapi-src/SYCLomatic/pull/1396) changes the function signatures of `dpct::tagged_pointer` and `dpct::release_temporary_allocation`. Therefore, it is necessary to adjust the tests for `onedpl_test_tagged_pointer`, `onedpl_test_malloc_free`, and `onedpl_test_temporary_allocation` to include these changes.

Please note that these tests will not pass in CI until the corresponding SYCLomatic PR is merged.