### PR TITLE
[SYCLomatic #1352] Add E2E tests for migration of thrust::get_temporary_buffer/return_temporary_buffer, thrust::malloc/free, thrust::device_new/device_delete

### DIFF
--- a/features/config/TEMPLATE_thrust_api_disable_win_and_noneusm.xml
+++ b/features/config/TEMPLATE_thrust_api_disable_win_and_noneusm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test driverID="test_feature" name="TEMPLATE">
+    <description>test</description>
+    <files>
+        <file path="feature_case/thrust/${testName}.cu" />
+    </files>
+    <rules>
+        <optlevelRule excludeOptlevelNameString="usmnone" />
+        <platformRule OSFamily="Linux" kit="CUDA9.2" kitRange="OLDER" runOnThisPlatform="false"/>
+        <platformRule OSFamily="Windows" runOnThisPlatform="false" />
+        <optlevelRule excludeOptlevelNameString="cuda" />
+    </rules>
+</test>

--- a/features/feature_case/thrust/thrust_device_new_delete.cu
+++ b/features/feature_case/thrust/thrust_device_new_delete.cu
@@ -7,7 +7,6 @@
 //
 // ===---------------------------------------------------------------------===//
 
-
 #include <thrust/device_delete.h>
 #include <thrust/device_malloc.h>
 #include <thrust/device_new.h>
@@ -42,11 +41,11 @@ void test_2() {
   int val = 46;
 
   thrust::device_ptr<int> d_mem = thrust::device_malloc<int>(N);
-  
+
   thrust::device_ptr<int> a;
   thrust::device_ptr<int> b;
   b = a;
-  
+
   thrust::device_ptr<int> d_array = thrust::device_new<int>(d_mem, N);
   thrust::uninitialized_fill(thrust::device, d_array, d_array + N, val);
 

--- a/features/feature_case/thrust/thrust_device_new_delete.cu
+++ b/features/feature_case/thrust/thrust_device_new_delete.cu
@@ -1,0 +1,92 @@
+// ====------ thrust_device_new_delete.cu--------------- *- CUDA -* ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===---------------------------------------------------------------------===//
+
+
+#include <thrust/device_delete.h>
+#include <thrust/device_malloc.h>
+#include <thrust/device_new.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/host_vector.h>
+#include <thrust/uninitialized_fill.h>
+
+void test_1() {
+  const int N = 137;
+  int val = 46;
+  thrust::device_ptr<int> d_array = thrust::device_new<int>(N);
+  thrust::uninitialized_fill(d_array, d_array + N, val);
+
+  thrust::host_vector<int> hostVec(d_array, d_array + N);
+
+  thrust::device_delete(d_array, N);
+
+  for (int i = 0; i < N; i++) {
+    if (hostVec[i] != 46) {
+      printf("test_1 run failed\n");
+      exit(-1);
+    }
+  }
+
+  printf("test_1 run passed!\n");
+}
+
+void test_2() {
+
+  const int N = 137;
+  int val = 46;
+
+  thrust::device_ptr<int> d_mem = thrust::device_malloc<int>(N);
+  
+  thrust::device_ptr<int> a;
+  thrust::device_ptr<int> b;
+  b = a;
+  
+  thrust::device_ptr<int> d_array = thrust::device_new<int>(d_mem, N);
+  thrust::uninitialized_fill(thrust::device, d_array, d_array + N, val);
+
+  thrust::host_vector<int> hostVec(d_array, d_array + N);
+
+  for (int i = 0; i < N; i++) {
+    if (hostVec[i] != 46) {
+      printf("test_2 run failed\n");
+      exit(-1);
+    }
+  }
+  thrust::device_delete(d_array, N);
+  printf("test_2 run passed!\n");
+}
+
+void test_3() {
+
+  const int N = 137;
+
+  int val = 46;
+  thrust::device_ptr<int> d_mem = thrust::device_malloc<int>(N);
+  thrust::device_ptr<int> d_array = thrust::device_new<int>(d_mem, val, N);
+
+  thrust::host_vector<int> hostVec(d_array, d_array + N);
+
+  for (int i = 0; i < N; i++) {
+    if (hostVec[i] != 46) {
+      printf("test_2 run failed\n");
+      exit(-1);
+    }
+  }
+  thrust::device_delete(d_array, N);
+  printf("test_3 run passed!\n");
+}
+
+int main() {
+
+  test_1();
+  test_2();
+  test_3();
+
+  return 0;
+}

--- a/features/feature_case/thrust/thrust_malloc_free.cu
+++ b/features/feature_case/thrust/thrust_malloc_free.cu
@@ -1,0 +1,39 @@
+// ====------ thrust_malloc_free.cu--------------- *- CUDA -* --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===-----------------------------------------------------------------===//
+
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/memory.h>
+
+int main() {
+
+  {
+    const int N = 100;
+    thrust::device_system_tag device_sys;
+    thrust::pointer<int, thrust::device_system_tag> ptr = thrust::malloc<int>(device_sys, N);
+
+    // deallocate ptr with thrust::free
+    thrust::free(device_sys, ptr);
+  }
+
+  {
+
+    // allocate some memory with thrust::malloc
+    const int N = 100;
+    thrust::device_system_tag device_sys;
+    thrust::pointer<void, thrust::device_system_tag> void_ptr = thrust::malloc(device_sys, N);
+    // manipulate memory
+
+    // deallocate void_ptr with thrust::free
+    thrust::free(device_sys, void_ptr);
+  }
+
+  return 0;
+}

--- a/features/feature_case/thrust/thrust_malloc_free.cu
+++ b/features/feature_case/thrust/thrust_malloc_free.cu
@@ -7,7 +7,6 @@
 //
 // ===-----------------------------------------------------------------===//
 
-
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 #include <thrust/memory.h>
@@ -17,7 +16,8 @@ int main() {
   {
     const int N = 100;
     thrust::device_system_tag device_sys;
-    thrust::pointer<int, thrust::device_system_tag> ptr = thrust::malloc<int>(device_sys, N);
+    thrust::pointer<int, thrust::device_system_tag> ptr =
+        thrust::malloc<int>(device_sys, N);
 
     // deallocate ptr with thrust::free
     thrust::free(device_sys, ptr);
@@ -28,7 +28,8 @@ int main() {
     // allocate some memory with thrust::malloc
     const int N = 100;
     thrust::device_system_tag device_sys;
-    thrust::pointer<void, thrust::device_system_tag> void_ptr = thrust::malloc(device_sys, N);
+    thrust::pointer<void, thrust::device_system_tag> void_ptr =
+        thrust::malloc(device_sys, N);
     // manipulate memory
 
     // deallocate void_ptr with thrust::free

--- a/features/feature_case/thrust/thrust_temporary_buffer.cu
+++ b/features/feature_case/thrust/thrust_temporary_buffer.cu
@@ -15,18 +15,21 @@ int main() {
 
   // allocate storage for 100 ints with thrust::get_temporary_buffer
   const int N = 100;
-  typedef thrust::pair<thrust::pointer<int, thrust::device_system_tag>, std::ptrdiff_t> ptr_and_size_t;
+  typedef thrust::pair<thrust::pointer<int, thrust::device_system_tag>,
+                       std::ptrdiff_t>
+      ptr_and_size_t;
   thrust::device_system_tag device_sys;
-  
-  ptr_and_size_t ptr_and_size =  thrust::get_temporary_buffer<int>(device_sys, N);
+
+  ptr_and_size_t ptr_and_size =
+      thrust::get_temporary_buffer<int>(device_sys, N);
   // manipulate up to 100 ints
   for (int i = 0; i < ptr_and_size.second; ++i) {
     *ptr_and_size.first = i;
   }
-  
-  
+
   // deallocate storage with thrust::return_temporary_buffer
-  thrust::return_temporary_buffer(device_sys, ptr_and_size.first, ptr_and_size.second);
+  thrust::return_temporary_buffer(device_sys, ptr_and_size.first,
+                                  ptr_and_size.second);
 
   return 0;
 }

--- a/features/feature_case/thrust/thrust_temporary_buffer.cu
+++ b/features/feature_case/thrust/thrust_temporary_buffer.cu
@@ -1,0 +1,32 @@
+// ====------ thrust_temporary_buffer.cu--------------- *- CUDA -* ----======//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===---------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/memory.h>
+
+int main() {
+
+  // allocate storage for 100 ints with thrust::get_temporary_buffer
+  const int N = 100;
+  typedef thrust::pair<thrust::pointer<int, thrust::device_system_tag>, std::ptrdiff_t> ptr_and_size_t;
+  thrust::device_system_tag device_sys;
+  
+  ptr_and_size_t ptr_and_size =  thrust::get_temporary_buffer<int>(device_sys, N);
+  // manipulate up to 100 ints
+  for (int i = 0; i < ptr_and_size.second; ++i) {
+    *ptr_and_size.first = i;
+  }
+  
+  
+  // deallocate storage with thrust::return_temporary_buffer
+  thrust::return_temporary_buffer(device_sys, ptr_and_size.first, ptr_and_size.second);
+
+  return 0;
+}

--- a/features/features.xml
+++ b/features/features.xml
@@ -77,6 +77,9 @@
     <test testName="thrust_stable_sort" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_tabulate" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_for_each_n" configFile="config/TEMPLATE_thrust_api.xml" />
+    <test testName="thrust_device_new_delete" configFile="config/TEMPLATE_thrust_api.xml" />
+    <test testName="thrust_temporary_buffer" configFile="config/TEMPLATE_thrust_api_disable_noneusm.xml" />
+    <test testName="thrust_malloc_free" configFile="config/TEMPLATE_thrust_api_disable_noneusm.xml" />
     <test testName="thrust-math" configFile="config/TEMPLATE_thrust_api_disable_win.xml" />
     <test testName="thrust-math1" configFile="config/TEMPLATE_thrust_api_disable_win.xml" />
     <test testName="thrust-math2" configFile="config/TEMPLATE_thrust_api_disable_win.xml" />

--- a/features/features.xml
+++ b/features/features.xml
@@ -77,8 +77,8 @@
     <test testName="thrust_stable_sort" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_tabulate" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_for_each_n" configFile="config/TEMPLATE_thrust_api.xml" />
-    <test testName="thrust_device_new_delete" configFile="config/TEMPLATE_thrust_api.xml" />
-    <test testName="thrust_temporary_buffer" configFile="config/TEMPLATE_thrust_api_disable_win.xml" />
+    <test testName="thrust_device_new_delete" configFile="config/TEMPLATE_thrust_api_disable_noneusm.xml" />
+    <test testName="thrust_temporary_buffer" configFile="config/TEMPLATE_thrust_api_disable_win_and_noneusm.xml" />
     <test testName="thrust_malloc_free" configFile="config/TEMPLATE_thrust_api_disable_noneusm.xml" />
     <test testName="thrust-math" configFile="config/TEMPLATE_thrust_api_disable_win.xml" />
     <test testName="thrust-math1" configFile="config/TEMPLATE_thrust_api_disable_win.xml" />

--- a/features/features.xml
+++ b/features/features.xml
@@ -78,7 +78,7 @@
     <test testName="thrust_tabulate" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_for_each_n" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_device_new_delete" configFile="config/TEMPLATE_thrust_api.xml" />
-    <test testName="thrust_temporary_buffer" configFile="config/TEMPLATE_thrust_api_disable_noneusm.xml" />
+    <test testName="thrust_temporary_buffer" configFile="config/TEMPLATE_thrust_api_disable_win.xml" />
     <test testName="thrust_malloc_free" configFile="config/TEMPLATE_thrust_api_disable_noneusm.xml" />
     <test testName="thrust-math" configFile="config/TEMPLATE_thrust_api_disable_win.xml" />
     <test testName="thrust-math1" configFile="config/TEMPLATE_thrust_api_disable_win.xml" />

--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -55,7 +55,8 @@ exec_tests = ['asm', 'asm_arith', 'asm_vinst', 'asm_v2inst', 'thrust-vector-2', 
               'thrust_random_type', 'thrust_scatter_if', 'thrust_all_of', 'thrust_none_of', 'thrust_is_partitioned',
               'thrust_is_sorted_until', 'thrust_set_intersection', 'thrust_set_union_by_key', 'thrust_set_union',
               'thrust_swap_ranges', 'thrust_uninitialized_fill_n', 'thrust_equal', 'system_atomic', 'thrust_detail_types',
-              'operator_eq', 'operator_neq', 'operator_lege', 'thrust_system', 'thrust_reverse_copy']
+              'operator_eq', 'operator_neq', 'operator_lege', 'thrust_system', 'thrust_reverse_copy',
+              'thrust_device_new_delete', 'thrust_temporary_buffer', 'thrust_malloc_free']
 
 occupancy_calculation_exper = ['occupancy_calculation']
 


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>