### PR TITLE
[SYCLomatic #1510] Add test cases for migration of two more overloading versions of thrust::gather_if.

### DIFF
--- a/features/feature_case/thrust/thrust-gather_if.cu
+++ b/features/feature_case/thrust/thrust-gather_if.cu
@@ -6,12 +6,15 @@
 //
 //
 // ===----------------------------------------------------------------------===//
+#include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
 #include <thrust/gather.h>
-#include <thrust/host_vector.h>
 
-struct is_odd {
-  __host__ __device__ bool operator()(const int x) const {
+struct is_odd
+{
+  __host__ __device__
+  bool operator()(const int x) const
+  {
     return (x % 2) == 1;
   }
 };
@@ -20,13 +23,13 @@ void test_1() {
   int values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
   int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
   thrust::device_vector<int> d_values(values, values + 10);
-  thrust::device_vector<int> d_stencil(stencil, stencil + 10);
+  thrust::device_vector<int> d_stencil(stencil, stencil + 10);  
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::device_vector<int> d_map(map, map + 10);
-  thrust::device_vector<int> d_output(10, 123);
+  thrust::device_vector<int> d_output(10,123);
 
-  thrust::gather_if(d_map.begin(), d_map.end(), d_stencil.begin(),
-                    d_values.begin(), d_output.begin(), is_odd());
+  thrust::gather_if(d_map.begin(), d_map.end(), d_stencil.begin(), d_values.begin(),
+                 d_output.begin(),is_odd());
 
   int values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
   for (int i = 0; i < d_output.size(); i++) {
@@ -41,15 +44,14 @@ void test_1() {
 
 void test_2() {
   int values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
   thrust::device_vector<int> d_values(values, values + 10);
-  thrust::device_vector<int> d_stencil(stencil, stencil + 10);
+  thrust::device_vector<int> d_stencil(stencil, stencil + 10);    
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::device_vector<int> d_map(map, map + 10);
-  thrust::device_vector<int> d_output(10, 123);
-  thrust::gather_if(thrust::device, d_map.begin(), d_map.end(),
-                    d_stencil.begin(), d_values.begin(), d_output.begin(),
-                    is_odd());
+  thrust::device_vector<int> d_output(10,123);
+  thrust::gather_if(thrust::device, d_map.begin(), d_map.end(), d_stencil.begin(), d_values.begin(),
+                 d_output.begin(),is_odd());
 
   int values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
 
@@ -64,14 +66,14 @@ void test_2() {
 
 void test_3() {
   int values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
   thrust::host_vector<int> h_values(values, values + 10);
-  thrust::host_vector<int> h_stencil(stencil, stencil + 10);
+  thrust::host_vector<int> h_stencil(stencil, stencil + 10);    
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::host_vector<int> h_map(map, map + 10);
-  thrust::host_vector<int> h_output(10, 123);
-  thrust::gather_if(thrust::seq, h_map.begin(), h_map.end(), h_stencil.begin(),
-                    h_values.begin(), h_output.begin(), is_odd());
+  thrust::host_vector<int> h_output(10,123);
+  thrust::gather_if(thrust::seq, h_map.begin(), h_map.end(), h_stencil.begin(), h_values.begin(),
+                 h_output.begin(),is_odd());
 
   int values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
 
@@ -86,14 +88,14 @@ void test_3() {
 
 void test_4() {
   int values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
   thrust::host_vector<int> h_values(values, values + 10);
   thrust::host_vector<int> h_stencil(stencil, stencil + 10);
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::host_vector<int> h_map(map, map + 10);
-  thrust::host_vector<int> h_output(10, 123);
-  thrust::gather_if(h_map.begin(), h_map.end(), h_stencil.begin(),
-                    h_values.begin(), h_output.begin(), is_odd());
+  thrust::host_vector<int> h_output(10,123);
+  thrust::gather_if(h_map.begin(), h_map.end(), h_stencil.begin(), h_values.begin(),
+                 h_output.begin(),is_odd());
 
   int values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
 
@@ -104,6 +106,100 @@ void test_4() {
     }
   }
   printf("test_4 run passed!\n");
+}
+
+
+template<typename T>
+void test_A() {
+  T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+  thrust::device_vector<T> d_values(values, values + 10);
+  thrust::device_vector<int> d_stencil(stencil, stencil + 10);    
+  int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
+  thrust::device_vector<int> d_map(map, map + 10);
+  thrust::device_vector<T> d_output(10,123);
+
+  thrust::gather_if(d_map.begin(), d_map.end(), d_stencil.begin(), d_values.begin(),
+                 d_output.begin(),is_odd());
+
+  T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
+  for (int i = 0; i < d_output.size(); i++) {
+    if (d_output[i] != values_ref[i]) {
+      printf("test_A run failed\n");
+      exit(-1);
+    }
+  }
+
+  printf("test_A run passed %ld!\n",sizeof(T));
+}
+
+template<typename T>
+void test_B() {
+  T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
+  thrust::device_vector<T> d_values(values, values + 10);
+  thrust::device_vector<int> d_stencil(stencil, stencil + 10);      
+  int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
+  thrust::device_vector<int> d_map(map, map + 10);
+  thrust::device_vector<T> d_output(10,123);
+  thrust::gather_if(thrust::device, d_map.begin(), d_map.end(), d_stencil.begin(), d_values.begin(),
+                 d_output.begin(),is_odd());
+
+  T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
+
+  for (int i = 0; i < d_output.size(); i++) {
+    if (d_output[i] != values_ref[i]) {
+      printf("test_B run failed\n");
+      exit(-1);
+    }
+  }
+  printf("test_B run passed %ld!\n",sizeof(T));
+}
+
+template<typename T>
+void test_C() {
+  T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
+  thrust::host_vector<T> h_values(values, values + 10);
+  thrust::host_vector<int> h_stencil(stencil, stencil + 10);      
+  int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
+  thrust::host_vector<int> h_map(map, map + 10);
+  thrust::host_vector<T> h_output(10,123);
+  thrust::gather_if(thrust::seq, h_map.begin(), h_map.end(), h_stencil.begin(), h_values.begin(),
+                 h_output.begin(),is_odd());
+
+  T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
+
+  for (int i = 0; i < h_output.size(); i++) {
+    if (h_output[i] != values_ref[i]) {
+      printf("test_C run failed\n");
+      exit(-1);
+    }
+  }
+  printf("test_C run passed %ld!\n",sizeof(T));
+}
+
+template<typename T>
+void test_D() {
+  T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
+  thrust::host_vector<T> h_values(values, values + 10);
+  thrust::host_vector<int> h_stencil(stencil, stencil + 10);
+  int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
+  thrust::host_vector<int> h_map(map, map + 10);
+  thrust::host_vector<T> h_output(10,123);
+  thrust::gather_if(h_map.begin(), h_map.end(), h_stencil.begin(), h_values.begin(),
+                 h_output.begin(),is_odd());
+
+  T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
+
+  for (int i = 0; i < h_output.size(); i++) {
+    if (h_output[i] != values_ref[i]) {
+      printf("test_D run failed\n");
+      exit(-1);
+    }
+  }
+  printf("test_D run passed %ld!\n",sizeof(T));
 }
 
 void test_5() {
@@ -124,7 +220,7 @@ void test_5() {
   int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
   for (int i = 0; i < d_output.size(); i++) {
     if (d_output[i] != values_ref[i]) {
-      printf("test_1 run failed\n");
+      printf("test_5 run failed\n");
       exit(-1);
     }
   }
@@ -150,7 +246,7 @@ void test_6() {
   int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
   for (int i = 0; i < d_output.size(); i++) {
     if (d_output[i] != values_ref[i]) {
-      printf("test_1 run failed\n");
+      printf("test_6 run failed\n");
       exit(-1);
     }
   }
@@ -176,7 +272,7 @@ void test_7() {
   int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
   for (int i = 0; i < d_output.size(); i++) {
     if (d_output[i] != values_ref[i]) {
-      printf("test_1 run failed\n");
+      printf("test_7 run failed\n");
       exit(-1);
     }
   }
@@ -202,7 +298,7 @@ void test_8() {
   int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
   for (int i = 0; i < d_output.size(); i++) {
     if (d_output[i] != values_ref[i]) {
-      printf("test_1 run failed\n");
+      printf("test_8 run failed\n");
       exit(-1);
     }
   }
@@ -225,7 +321,7 @@ void test_9() {
   int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
   for (int i = 0; i < 10; i++) {
     if (output[i] != values_ref[i]) {
-      printf("test_10 run failed\n");
+      printf("test_9 run failed\n");
       exit(-1);
     }
   }
@@ -293,96 +389,6 @@ void test_12() {
     }
   }
   printf("test_12 run passed!\n");
-}
-
-template <typename T> void test_A() {
-  T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
-  thrust::device_vector<T> d_values(values, values + 10);
-  thrust::device_vector<int> d_stencil(stencil, stencil + 10);
-  int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
-  thrust::device_vector<int> d_map(map, map + 10);
-  thrust::device_vector<T> d_output(10, 123);
-
-  thrust::gather_if(d_map.begin(), d_map.end(), d_stencil.begin(),
-                    d_values.begin(), d_output.begin(), is_odd());
-
-  T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
-  for (int i = 0; i < d_output.size(); i++) {
-    if (d_output[i] != values_ref[i]) {
-      printf("test_A run failed\n");
-      exit(-1);
-    }
-  }
-
-  printf("test_A run passed %ld!\n", sizeof(T));
-}
-
-template <typename T> void test_B() {
-  T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
-  thrust::device_vector<T> d_values(values, values + 10);
-  thrust::device_vector<int> d_stencil(stencil, stencil + 10);
-  int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
-  thrust::device_vector<int> d_map(map, map + 10);
-  thrust::device_vector<T> d_output(10, 123);
-  thrust::gather_if(thrust::device, d_map.begin(), d_map.end(),
-                    d_stencil.begin(), d_values.begin(), d_output.begin(),
-                    is_odd());
-
-  T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
-
-  for (int i = 0; i < d_output.size(); i++) {
-    if (d_output[i] != values_ref[i]) {
-      printf("test_B run failed\n");
-      exit(-1);
-    }
-  }
-  printf("test_B run passed %ld!\n", sizeof(T));
-}
-
-template <typename T> void test_C() {
-  T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
-  thrust::host_vector<T> h_values(values, values + 10);
-  thrust::host_vector<int> h_stencil(stencil, stencil + 10);
-  int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
-  thrust::host_vector<int> h_map(map, map + 10);
-  thrust::host_vector<T> h_output(10, 123);
-  thrust::gather_if(thrust::seq, h_map.begin(), h_map.end(), h_stencil.begin(),
-                    h_values.begin(), h_output.begin(), is_odd());
-
-  T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
-
-  for (int i = 0; i < h_output.size(); i++) {
-    if (h_output[i] != values_ref[i]) {
-      printf("test_C run failed\n");
-      exit(-1);
-    }
-  }
-  printf("test_C run passed %ld!\n", sizeof(T));
-}
-
-template <typename T> void test_D() {
-  T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
-  thrust::host_vector<T> h_values(values, values + 10);
-  thrust::host_vector<int> h_stencil(stencil, stencil + 10);
-  int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
-  thrust::host_vector<int> h_map(map, map + 10);
-  thrust::host_vector<T> h_output(10, 123);
-  thrust::gather_if(h_map.begin(), h_map.end(), h_stencil.begin(),
-                    h_values.begin(), h_output.begin(), is_odd());
-
-  T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
-
-  for (int i = 0; i < h_output.size(); i++) {
-    if (h_output[i] != values_ref[i]) {
-      printf("test_D run failed\n");
-      exit(-1);
-    }
-  }
-  printf("test_D run passed %ld!\n", sizeof(T));
 }
 
 int main() {

--- a/features/feature_case/thrust/thrust-gather_if.cu
+++ b/features/feature_case/thrust/thrust-gather_if.cu
@@ -398,7 +398,7 @@ int main() {
   test_4();
   test_5();
   test_6();
-  test_7();
+  // test_7();
   test_8();
   test_9();
   test_10();

--- a/features/feature_case/thrust/thrust-gather_if.cu
+++ b/features/feature_case/thrust/thrust-gather_if.cu
@@ -6,15 +6,12 @@
 //
 //
 // ===----------------------------------------------------------------------===//
-#include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
 #include <thrust/gather.h>
+#include <thrust/host_vector.h>
 
-struct is_odd
-{
-  __host__ __device__
-  bool operator()(const int x) const
-  {
+struct is_odd {
+  __host__ __device__ bool operator()(const int x) const {
     return (x % 2) == 1;
   }
 };
@@ -23,13 +20,13 @@ void test_1() {
   int values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
   int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
   thrust::device_vector<int> d_values(values, values + 10);
-  thrust::device_vector<int> d_stencil(stencil, stencil + 10);  
+  thrust::device_vector<int> d_stencil(stencil, stencil + 10);
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::device_vector<int> d_map(map, map + 10);
-  thrust::device_vector<int> d_output(10,123);
+  thrust::device_vector<int> d_output(10, 123);
 
-  thrust::gather_if(d_map.begin(), d_map.end(), d_stencil.begin(), d_values.begin(),
-                 d_output.begin(),is_odd());
+  thrust::gather_if(d_map.begin(), d_map.end(), d_stencil.begin(),
+                    d_values.begin(), d_output.begin(), is_odd());
 
   int values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
   for (int i = 0; i < d_output.size(); i++) {
@@ -44,14 +41,15 @@ void test_1() {
 
 void test_2() {
   int values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
   thrust::device_vector<int> d_values(values, values + 10);
-  thrust::device_vector<int> d_stencil(stencil, stencil + 10);    
+  thrust::device_vector<int> d_stencil(stencil, stencil + 10);
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::device_vector<int> d_map(map, map + 10);
-  thrust::device_vector<int> d_output(10,123);
-  thrust::gather_if(thrust::device, d_map.begin(), d_map.end(), d_stencil.begin(), d_values.begin(),
-                 d_output.begin(),is_odd());
+  thrust::device_vector<int> d_output(10, 123);
+  thrust::gather_if(thrust::device, d_map.begin(), d_map.end(),
+                    d_stencil.begin(), d_values.begin(), d_output.begin(),
+                    is_odd());
 
   int values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
 
@@ -66,14 +64,14 @@ void test_2() {
 
 void test_3() {
   int values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
   thrust::host_vector<int> h_values(values, values + 10);
-  thrust::host_vector<int> h_stencil(stencil, stencil + 10);    
+  thrust::host_vector<int> h_stencil(stencil, stencil + 10);
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::host_vector<int> h_map(map, map + 10);
-  thrust::host_vector<int> h_output(10,123);
-  thrust::gather_if(thrust::seq, h_map.begin(), h_map.end(), h_stencil.begin(), h_values.begin(),
-                 h_output.begin(),is_odd());
+  thrust::host_vector<int> h_output(10, 123);
+  thrust::gather_if(thrust::seq, h_map.begin(), h_map.end(), h_stencil.begin(),
+                    h_values.begin(), h_output.begin(), is_odd());
 
   int values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
 
@@ -88,14 +86,14 @@ void test_3() {
 
 void test_4() {
   int values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
   thrust::host_vector<int> h_values(values, values + 10);
   thrust::host_vector<int> h_stencil(stencil, stencil + 10);
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::host_vector<int> h_map(map, map + 10);
-  thrust::host_vector<int> h_output(10,123);
-  thrust::gather_if(h_map.begin(), h_map.end(), h_stencil.begin(), h_values.begin(),
-                 h_output.begin(),is_odd());
+  thrust::host_vector<int> h_output(10, 123);
+  thrust::gather_if(h_map.begin(), h_map.end(), h_stencil.begin(),
+                    h_values.begin(), h_output.begin(), is_odd());
 
   int values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
 
@@ -108,19 +106,206 @@ void test_4() {
   printf("test_4 run passed!\n");
 }
 
+void test_5() {
 
-template<typename T>
-void test_A() {
+  int values[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  thrust::device_vector<int> d_values(values, values + 10);
+  // select elements at even-indexed locations
+  int stencil[10] = {1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+  thrust::device_vector<int> d_stencil(stencil, stencil + 10);
+  // map all even indices into the first half of the range
+  // and odd indices to the last half of the range
+  int map[10] = {0, 2, 4, 6, 8, 1, 3, 5, 7, 9};
+  thrust::device_vector<int> d_map(map, map + 10);
+  thrust::device_vector<int> d_output(10, 7);
+  thrust::gather_if(thrust::device, d_map.begin(), d_map.end(),
+                    d_stencil.begin(), d_values.begin(), d_output.begin());
+
+  int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
+  for (int i = 0; i < d_output.size(); i++) {
+    if (d_output[i] != values_ref[i]) {
+      printf("test_1 run failed\n");
+      exit(-1);
+    }
+  }
+
+  printf("test_5 run passed!\n");
+}
+
+void test_6() {
+
+  int values[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  thrust::device_vector<int> d_values(values, values + 10);
+  // select elements at even-indexed locations
+  int stencil[10] = {1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+  thrust::device_vector<int> d_stencil(stencil, stencil + 10);
+  // map all even indices into the first half of the range
+  // and odd indices to the last half of the range
+  int map[10] = {0, 2, 4, 6, 8, 1, 3, 5, 7, 9};
+  thrust::device_vector<int> d_map(map, map + 10);
+  thrust::device_vector<int> d_output(10, 7);
+  thrust::gather_if(d_map.begin(), d_map.end(), d_stencil.begin(),
+                    d_values.begin(), d_output.begin());
+
+  int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
+  for (int i = 0; i < d_output.size(); i++) {
+    if (d_output[i] != values_ref[i]) {
+      printf("test_1 run failed\n");
+      exit(-1);
+    }
+  }
+
+  printf("test_6 run passed!\n");
+}
+
+void test_7() {
+
+  int values[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  thrust::host_vector<int> h_values(values, values + 10);
+  // select elements at even-indexed locations
+  int stencil[10] = {1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+  thrust::host_vector<int> d_stencil(stencil, stencil + 10);
+  // map all even indices into the first half of the range
+  // and odd indices to the last half of the range
+  int map[10] = {0, 2, 4, 6, 8, 1, 3, 5, 7, 9};
+  thrust::host_vector<int> d_map(map, map + 10);
+  thrust::host_vector<int> d_output(10, 7);
+  thrust::gather_if(thrust::host, d_map.begin(), d_map.end(), d_stencil.begin(),
+                    h_values.begin(), d_output.begin());
+
+  int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
+  for (int i = 0; i < d_output.size(); i++) {
+    if (d_output[i] != values_ref[i]) {
+      printf("test_1 run failed\n");
+      exit(-1);
+    }
+  }
+
+  printf("test_7 run passed!\n");
+}
+
+void test_8() {
+
+  int values[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  thrust::host_vector<int> h_values(values, values + 10);
+  // select elements at even-indexed locations
+  int stencil[10] = {1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+  thrust::host_vector<int> d_stencil(stencil, stencil + 10);
+  // map all even indices into the first half of the range
+  // and odd indices to the last half of the range
+  int map[10] = {0, 2, 4, 6, 8, 1, 3, 5, 7, 9};
+  thrust::host_vector<int> d_map(map, map + 10);
+  thrust::host_vector<int> d_output(10, 7);
+  thrust::gather_if(d_map.begin(), d_map.end(), d_stencil.begin(),
+                    h_values.begin(), d_output.begin());
+
+  int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
+  for (int i = 0; i < d_output.size(); i++) {
+    if (d_output[i] != values_ref[i]) {
+      printf("test_1 run failed\n");
+      exit(-1);
+    }
+  }
+
+  printf("test_8 run passed!\n");
+}
+
+void test_9() {
+
+  int values[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  int stencil[10] = {1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+
+  // and odd indices to the last half of the range
+
+  int map[10] = {0, 2, 4, 6, 8, 1, 3, 5, 7, 9};
+
+  int output[10] = {7, 7, 7, 7, 7, 7, 7, 7, 7, 7};
+  thrust::gather_if(thrust::host, map, map + 10, stencil, values, output);
+
+  int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
+  for (int i = 0; i < 10; i++) {
+    if (output[i] != values_ref[i]) {
+      printf("test_10 run failed\n");
+      exit(-1);
+    }
+  }
+
+  printf("test_9 run passed!\n");
+}
+
+void test_10() {
+
+  int values[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  int stencil[10] = {1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+
+  // and odd indices to the last half of the range
+
+  int map[10] = {0, 2, 4, 6, 8, 1, 3, 5, 7, 9};
+
+  int output[10] = {7, 7, 7, 7, 7, 7, 7, 7, 7, 7};
+  thrust::gather_if(map, map + 10, stencil, values, output);
+
+  int values_ref[10] = {0, 7, 4, 7, 8, 7, 3, 7, 7, 7};
+  for (int i = 0; i < 10; i++) {
+    if (output[i] != values_ref[i]) {
+      printf("test_10 run failed\n");
+      exit(-1);
+    }
+  }
+
+  printf("test_10 run passed!\n");
+}
+
+void test_11() {
+  int values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+
+  int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
+  int output[10] = {123, 123, 123, 123, 123, 123, 123, 123, 123, 123};
+  thrust::gather_if(thrust::seq, map, map + 10, stencil, values, output,
+                    is_odd());
+
+  int values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
+
+  for (int i = 0; i < 10; i++) {
+    if (output[i] != values_ref[i]) {
+      printf("test_11 run failed\n");
+      exit(-1);
+    }
+  }
+  printf("test_11 run passed!\n");
+}
+
+void test_12() {
+  int values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+
+  int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
+  int output[10] = {123, 123, 123, 123, 123, 123, 123, 123, 123, 123};
+  thrust::gather_if(map, map + 10, stencil, values, output, is_odd());
+
+  int values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
+
+  for (int i = 0; i < 10; i++) {
+    if (output[i] != values_ref[i]) {
+      printf("test_12 run failed\n");
+      exit(-1);
+    }
+  }
+  printf("test_12 run passed!\n");
+}
+
+template <typename T> void test_A() {
   T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
   int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
   thrust::device_vector<T> d_values(values, values + 10);
-  thrust::device_vector<int> d_stencil(stencil, stencil + 10);    
+  thrust::device_vector<int> d_stencil(stencil, stencil + 10);
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::device_vector<int> d_map(map, map + 10);
-  thrust::device_vector<T> d_output(10,123);
+  thrust::device_vector<T> d_output(10, 123);
 
-  thrust::gather_if(d_map.begin(), d_map.end(), d_stencil.begin(), d_values.begin(),
-                 d_output.begin(),is_odd());
+  thrust::gather_if(d_map.begin(), d_map.end(), d_stencil.begin(),
+                    d_values.begin(), d_output.begin(), is_odd());
 
   T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
   for (int i = 0; i < d_output.size(); i++) {
@@ -130,20 +315,20 @@ void test_A() {
     }
   }
 
-  printf("test_A run passed %ld!\n",sizeof(T));
+  printf("test_A run passed %ld!\n", sizeof(T));
 }
 
-template<typename T>
-void test_B() {
+template <typename T> void test_B() {
   T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
   thrust::device_vector<T> d_values(values, values + 10);
-  thrust::device_vector<int> d_stencil(stencil, stencil + 10);      
+  thrust::device_vector<int> d_stencil(stencil, stencil + 10);
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::device_vector<int> d_map(map, map + 10);
-  thrust::device_vector<T> d_output(10,123);
-  thrust::gather_if(thrust::device, d_map.begin(), d_map.end(), d_stencil.begin(), d_values.begin(),
-                 d_output.begin(),is_odd());
+  thrust::device_vector<T> d_output(10, 123);
+  thrust::gather_if(thrust::device, d_map.begin(), d_map.end(),
+                    d_stencil.begin(), d_values.begin(), d_output.begin(),
+                    is_odd());
 
   T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
 
@@ -153,20 +338,19 @@ void test_B() {
       exit(-1);
     }
   }
-  printf("test_B run passed %ld!\n",sizeof(T));
+  printf("test_B run passed %ld!\n", sizeof(T));
 }
 
-template<typename T>
-void test_C() {
+template <typename T> void test_C() {
   T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
   thrust::host_vector<T> h_values(values, values + 10);
-  thrust::host_vector<int> h_stencil(stencil, stencil + 10);      
+  thrust::host_vector<int> h_stencil(stencil, stencil + 10);
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::host_vector<int> h_map(map, map + 10);
-  thrust::host_vector<T> h_output(10,123);
-  thrust::gather_if(thrust::seq, h_map.begin(), h_map.end(), h_stencil.begin(), h_values.begin(),
-                 h_output.begin(),is_odd());
+  thrust::host_vector<T> h_output(10, 123);
+  thrust::gather_if(thrust::seq, h_map.begin(), h_map.end(), h_stencil.begin(),
+                    h_values.begin(), h_output.begin(), is_odd());
 
   T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
 
@@ -176,20 +360,19 @@ void test_C() {
       exit(-1);
     }
   }
-  printf("test_C run passed %ld!\n",sizeof(T));
+  printf("test_C run passed %ld!\n", sizeof(T));
 }
 
-template<typename T>
-void test_D() {
+template <typename T> void test_D() {
   T values[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
-  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};  
+  int stencil[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
   thrust::host_vector<T> h_values(values, values + 10);
   thrust::host_vector<int> h_stencil(stencil, stencil + 10);
   int map[10] = {9, 8, 7, 6, 5, 0, 1, 2, 3, 4};
   thrust::host_vector<int> h_map(map, map + 10);
-  thrust::host_vector<T> h_output(10,123);
-  thrust::gather_if(h_map.begin(), h_map.end(), h_stencil.begin(), h_values.begin(),
-                 h_output.begin(),is_odd());
+  thrust::host_vector<T> h_output(10, 123);
+  thrust::gather_if(h_map.begin(), h_map.end(), h_stencil.begin(),
+                    h_values.begin(), h_output.begin(), is_odd());
 
   T values_ref[10] = {123, 9, 123, 7, 123, 1, 123, 3, 123, 5};
 
@@ -199,7 +382,7 @@ void test_D() {
       exit(-1);
     }
   }
-  printf("test_D run passed %ld!\n",sizeof(T));
+  printf("test_D run passed %ld!\n", sizeof(T));
 }
 
 int main() {
@@ -207,6 +390,14 @@ int main() {
   test_2();
   test_3();
   test_4();
+  test_5();
+  test_6();
+  test_7();
+  test_8();
+  test_9();
+  test_10();
+  test_11();
+  test_12();
 
   std::cout << "Testing char\n";
   test_A<char>();
@@ -237,12 +428,12 @@ int main() {
   test_B<long long>();
   test_C<long long>();
   test_D<long long>();
-  
+
   std::cout << "Testing float\n";
   test_A<float>();
   test_B<float>();
   test_C<float>();
   test_D<float>();
-  
+
   return 0;
 }


### PR DESCRIPTION
[SYCLomatic #1510] Add test cases for migration of two more overloading versions of thrust::gather_if.

Test to migrate six args version with policy specified.
Test to migrate five args version without policy specified.

Signed-off-by: chenwei.sun <chenwei.sun@intel.com>