### PR TITLE
[SYCLomatic] Enable test_cusparseTcsrsv2 for non-USM test

### DIFF
--- a/features/feature_case/cusparse/cusparse_6.cu
+++ b/features/feature_case/cusparse/cusparse_6.cu
@@ -245,9 +245,7 @@ void test_cusparseTcsrsv2() {
 }
 
 int main() {
-#ifndef DPCT_USM_LEVEL_NONE
   test_cusparseTcsrsv2();
-#endif
 
   if (test_passed)
     return 0;

--- a/help_function/src/sparse_utils_3_buffer.cpp
+++ b/help_function/src/sparse_utils_3_buffer.cpp
@@ -547,9 +547,7 @@ void test_cusparseTcsrmm2() {
 
 int main() {
   test_cusparseTcsrsv();
-#ifndef DPCT_USM_LEVEL_NONE
   test_cusparseTcsrsv2();
-#endif
   test_cusparseTcsrmm2();
 
   if (test_passed)

--- a/help_function/src/sparse_utils_3_usm.cpp
+++ b/help_function/src/sparse_utils_3_usm.cpp
@@ -554,9 +554,7 @@ void test_cusparseTcsrmm2() {
 
 int main() {
   test_cusparseTcsrsv();
-#ifndef DPCT_USM_LEVEL_NONE
   test_cusparseTcsrsv2();
-#endif
   test_cusparseTcsrmm2();
 
   if (test_passed)


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>