### PR TITLE
Remove Intel SYCL cmake package

### DIFF
--- a/behavior_tests/src/cmake_dpct_helper_sycl_compile/CMakeLists.txt
+++ b/behavior_tests/src/cmake_dpct_helper_sycl_compile/CMakeLists.txt
@@ -10,7 +10,6 @@ project(cuda_compile_sample)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
 
-find_package(IntelSYCL REQUIRED)
 find_program(
   DPCT_BIN_PATH
   NAMES dpct


### PR DESCRIPTION
We see a yet-to-be understood error due to this.
```
$ cmake -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=icpx -B build -S .
CMake Error at Modules/FindPackageHandleStandardArgs.cmake:195 (message):
  Unknown keywords given to FIND_PACKAGE_HANDLE_STANDARD_ARGS():
  "REASON_FAILURE_MESSAGE"
Call Stack (most recent call first):
/lib/cmake/IntelSYCL/IntelSYCLConfig.cmake:316 (find_package_handle_standard_args)
  CMakeLists.txt:13 (find_package)

-- Configuring incomplete, errors occurred!
```
This issue doesn't exist in cmake 3.25.3