### PR TITLE
[SYCLomatic] Add additional debugging information to onedpl_test_uninitialized_fill and onedpl_test_translate_key

### DIFF
--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -136,8 +136,8 @@
     <!-- <test testName="onedpl_test_transform" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" /> -->
     <test testName="onedpl_test_transform_output_iterator" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_transform_reduce" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />
-    <!-- <test testName="onedpl_test_translate_key" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" /> -->
-    <!-- <test testName="onedpl_test_uninitialized_fill" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" /> -->
+    <test testName="onedpl_test_translate_key" configFile="config/TEMPLATE_help_function_skip_double.xml"  splitGroup="double" />
+    <test testName="onedpl_test_uninitialized_fill" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_unique_by_key_copy" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_unique_by_key" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_unique" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />

--- a/help_function/src/onedpl_test_translate_key.cpp
+++ b/help_function/src/onedpl_test_translate_key.cpp
@@ -18,6 +18,9 @@
 
 #include <iostream>
 
+// TODO: If this test remains stable, then we may remove this macro entirely.
+#define VERBOSE_DEBUG
+
 template <typename String, typename _T1, typename _T2>
 int ASSERT_EQUAL(_T1 &&X, _T2 &&Y, String msg) {
   if (X != Y) {
@@ -44,6 +47,13 @@ void expect_rvalues(T_conv &&_expected, T &&_actual, const char *err_string) {
 
 int main() {
 
+// Print sizeof types we test
+#ifdef VERBOSE_DEBUG
+    std::cout << "onedpl_test_translate_key - sizeof test types:" << std::endl;
+    std::cout << "sizeof(int) = " << sizeof(int) << std::endl;
+    std::cout << "sizeof(float) = " << sizeof(float) << std::endl;
+    std::cout << "sizeof(double) = " << sizeof(double) << std::endl;
+#endif
   int test_suites_failed = 0;
   {
     ::std::string test_name = "translate int->uint32_t";


### PR DESCRIPTION
`onedpl_test_uninitialized_fill` and `onedpl_test_translate_key` have been reported as flaky and have been disabled in `help_function.xml`. Since we have been unable to reproduce these failures on our side, I have added additional debugging info to these tests, so we can better understand the cause of these failures when they arise.

The following changes have been made:

- From a visual inspection of the test, `onedpl_test_uninitialized_fill` is relying on uninitialized memory to not evaluate to a certain value. This is undefined behavior and is presumably the cause of the reported failures. I have reworked this portion of the test to remove this UB.
- If the `uninitialized_fill with USM allocation 2` fails (the problematic test case), then the expected and actual values for the full buffer of 16 elements are printed.
- Size types of the different translated values in `onedpl_test_translate_key` are now logged in the test as this is a suspected cause of the failures.
- The two failing tests have been restored so that we may test with this new debugging info and get more information if the failures still exist.