### PR TITLE
[SYCLomatic] Update thrust_unique_count to skip cuda header version older than 12.0 in which thrust::unique_count is not supported

### DIFF
--- a/features/config/TEMPLATE_thrust_unique_count.xml
+++ b/features/config/TEMPLATE_thrust_unique_count.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test driverID="test_feature" name="TEMPLATE">
+    <description>test</description>
+    <files>
+        <file path="feature_case/thrust/${testName}.cu" />
+        <file path="feature_case/thrust/report.h" />
+    </files>
+    <rules>
+        <optlevelRule excludeOptlevelNameString="usmnone" />
+        <platformRule OSFamily="Linux" kit="CUDA12.0" kitRange="OLDER" runOnThisPlatform="false"/>
+        <platformRule OSFamily="Windows" kit="CUDA12.0" kitRange="OLDER" runOnThisPlatform="false"/>
+        <optlevelRule excludeOptlevelNameString="cuda" />
+    </rules>
+</test>

--- a/features/features.xml
+++ b/features/features.xml
@@ -51,7 +51,7 @@
     <test testName="thrust_reverse_copy" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_all_of" configFile="config/TEMPLATE_thrust_exec_disable_noneusm.xml" />
     <test testName="thrust_none_of" configFile="config/TEMPLATE_thrust_exec_disable_noneusm.xml" />
-    <test testName="thrust_unique_count" configFile="config/TEMPLATE_thrust_exec_disable_noneusm.xml" />
+    <test testName="thrust_unique_count" configFile="config/TEMPLATE_thrust_unique_count.xml" />
     <test testName="thrust_is_partitioned" configFile="config/TEMPLATE_thrust_exec_disable_noneusm.xml" />
     <test testName="thrust_is_sorted_until" configFile="config/TEMPLATE_thrust_exec_disable_noneusm.xml" />
     <test testName="thrust_set_intersection" configFile="config/TEMPLATE_thrust_exec_disable_noneusm.xml" />


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>