### PR TITLE
[SYCLomatic #1785] Add test case for migration of thrust::make_transform_output_iterator and thrust::advance

### DIFF
--- a/features/feature_case/thrust/thrust_advance_trans_op_itr.cu
+++ b/features/feature_case/thrust/thrust_advance_trans_op_itr.cu
@@ -1,0 +1,64 @@
+// ====------ thrust_advance_trans_op_itr.cu----- *- CUDA -*--------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <iostream>
+#include <thrust/advance.h>
+#include <thrust/device_vector.h>
+#include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/sequence.h>
+#include <thrust/transform.h>
+
+struct square {
+  __host__ __device__ int operator()(int x) const { return x * x; }
+};
+
+void test_1() {
+  const int N = 5;
+  thrust::device_vector<int> vec(N);
+  thrust::sequence(vec.begin(), vec.end());
+
+  auto output_iter =
+      thrust::make_transform_output_iterator(vec.begin(), square());
+
+  thrust::transform(vec.begin(), vec.end(), output_iter, square());
+
+  int ans[N] = {0, 1, 16, 81, 256};
+
+  for (int i = 0; i < N; i++) {
+    if (vec[i] != ans[i]) {
+      printf("test_1 run failed\n");
+      exit(-1);
+    }
+  }
+
+  printf("test_1 run passed!\n");
+}
+
+void test_2() {
+  const int N = 5;
+  thrust::device_vector<int> vec(N);
+  thrust::sequence(vec.begin(), vec.end());
+
+  thrust::device_vector<int>::iterator iter = vec.begin();
+  thrust::advance(iter, 2); // Advance by 2 steps
+
+  if (*iter != 2) {
+    printf("test_2 run failed\n");
+    exit(-1);
+  }
+
+  printf("test_2 run passed!\n");
+}
+
+int main() {
+  test_1();
+  test_2();
+
+  return 0;
+}

--- a/features/features.xml
+++ b/features/features.xml
@@ -45,6 +45,7 @@
     <test testName="thrust_system" configFile="config/TEMPLATE_thrust_exec_disable_noneusm.xml" />
     <test testName="thrust_stable_partition" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_random_type" configFile="config/TEMPLATE_thrust_api.xml" />
+    <test testName="thrust_advance_trans_op_itr" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_uninitialized_fill_n" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_swap_ranges" configFile="config/TEMPLATE_thrust_api.xml" />
     <test testName="thrust_reverse" configFile="config/TEMPLATE_thrust_api.xml" />

--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -56,7 +56,8 @@ exec_tests = ['asm', 'asm_bar', 'asm_arith', 'asm_vinst', 'asm_v2inst', 'asm_v4i
               'thrust_is_sorted_until', 'thrust_set_intersection', 'thrust_set_union_by_key', 'thrust_set_union',
               'thrust_swap_ranges', 'thrust_uninitialized_fill_n', 'thrust_equal', 'system_atomic', 'thrust_detail_types',
               'operator_eq', 'operator_neq', 'operator_lege', 'thrust_system', 'thrust_reverse_copy',
-              'thrust_device_new_delete', 'thrust_temporary_buffer', 'thrust_malloc_free', 'codepin', 'thrust_unique_count']
+              'thrust_device_new_delete', 'thrust_temporary_buffer', 'thrust_malloc_free', 'codepin', 'thrust_unique_count',
+              'thrust_advance_trans_op_itr']
 
 occupancy_calculation_exper = ['occupancy_calculation']
 


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
