### PR TITLE
[SYCLomatic] Update test case thrust-sort_by_key.cu to fix dpct parse error "no member named 'find_if_not' in namespace 'thrust'" on Windows

### DIFF
--- a/features/feature_case/thrust/thrust-sort_by_key.cu
+++ b/features/feature_case/thrust/thrust-sort_by_key.cu
@@ -7,6 +7,7 @@
 // ===----------------------------------------------------------------------===//
 
 #include <thrust/device_vector.h>
+#include <thrust/find.h>
 #include <thrust/sort.h>
 #include <thrust/execution_policy.h>
 #include <thrust/functional.h>


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>