### PR TITLE
[SYCLomatic] Remove the is_host in the helper function test since the API was removed from SYCL header

### DIFF
--- a/help_function/src/c2s_device_info.cpp
+++ b/help_function/src/c2s_device_info.cpp
@@ -43,8 +43,6 @@ int main() {
       dev_info_output(device, "gpu  device");
   if(device.is_cpu())
       dev_info_output(device, "cpu  device");
-  if(device.is_host())
-      dev_info_output(device, "host device");
   if(device.is_accelerator())
       dev_info_output(device, "accelerator device");
 

--- a/help_function/src/dpct_device_info.cpp
+++ b/help_function/src/dpct_device_info.cpp
@@ -43,8 +43,6 @@ int main() {
       dev_info_output(device, "gpu  device");
   if(device.is_cpu())
       dev_info_output(device, "cpu  device");
-  if(device.is_host())
-      dev_info_output(device, "host device");
   if(device.is_accelerator())
       dev_info_output(device, "accelerator device");
 


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>