### PR TITLE
[SYCLomatic #2175] Remove test for dpct::device_info::set_max_work_item_sizes(const sycl::id<3>) since it is deprecated and will be removed

### DIFF
--- a/help_function/src/device_device_info.cpp
+++ b/help_function/src/device_device_info.cpp
@@ -64,10 +64,6 @@ int main() {
   // test_feature:set_name(Name)
   Info.set_name(Name);
 
-  sycl::id<3> max_work_item_sizes;
-  // test_feature:set_max_work_item_sizes(max_work_item_sizes)
-  Info.set_max_work_item_sizes(max_work_item_sizes);
-
   // test_feature:set_host_unified_memory(true)
   Info.set_host_unified_memory(true);
 


### PR DESCRIPTION
Signed-off-by: Jiang, Zhiwei <zhiwei.jiang@intel.com>