### PR TITLE
[SYCLomatic] Add test for `cuCtxPushCurrent`, `cuCtxPopCurrent`, `cuStreamQuery`, `cuCtxEnablePeerAccess` and `cuDeviceCanAccessPeer`

### DIFF
--- a/features/config/TEMPLATE_context_push_n_pop.xml
+++ b/features/config/TEMPLATE_context_push_n_pop.xml
@@ -3,8 +3,7 @@
 <test driverID="test_feature" name="TEMPLATE">
     <description>test</description>
     <files>
-      <file path="feature_case/driverStreamAndEvent/driverStreamAndEvent.cu" />
-      <file path="feature_case/driverStreamAndEvent/driverStreamQuery.cu" />
+        <file path="feature_case/context_push_n_pop/${testName}.cu" />
     </files>
     <rules />
 </test>

--- a/features/config/TEMPLATE_peer_access_using_driver_api.xml
+++ b/features/config/TEMPLATE_peer_access_using_driver_api.xml
@@ -3,8 +3,7 @@
 <test driverID="test_feature" name="TEMPLATE">
     <description>test</description>
     <files>
-      <file path="feature_case/driverStreamAndEvent/driverStreamAndEvent.cu" />
-      <file path="feature_case/driverStreamAndEvent/driverStreamQuery.cu" />
+        <file path="feature_case/peer_access_using_driver_api/${testName}.cu" />
     </files>
     <rules />
 </test>

--- a/features/feature_case/context_push_n_pop/context_push_n_pop.cu
+++ b/features/feature_case/context_push_n_pop/context_push_n_pop.cu
@@ -1,0 +1,71 @@
+#include <cuda.h>
+#include <iostream>
+
+void checkCUDAError(CUresult result) {
+    if (result != CUDA_SUCCESS) {
+        const char* errorStr;
+        cuGetErrorString(result, &errorStr);
+        std::cerr << "CUDA Error: " << errorStr << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main() {
+    CUcontext ctx1, ctx2;
+    CUdevice device;
+    CUresult result;
+
+    // Initialize the CUDA Driver API
+    result = cuInit(0);
+    checkCUDAError(result);
+
+    // Get the device
+    result = cuDeviceGet(&device, 0);
+    checkCUDAError(result);
+
+    // Create the first context
+    result = cuCtxCreate(&ctx1, 0, device);
+    checkCUDAError(result);
+
+    // Create the second context
+    result = cuCtxCreate(&ctx2, 0, device);
+    checkCUDAError(result);
+
+    // Get the current context and push it onto the stack
+    CUcontext currentCtx;
+    result = cuCtxGetCurrent(&currentCtx);
+    checkCUDAError(result);
+
+    result = cuCtxPushCurrent(ctx1);
+    checkCUDAError(result);
+
+    // Now the current context is ctx1
+    std::cout << "Context 1 is now current" << std::endl;
+
+    // Push the current context (ctx1) and switch to ctx2
+    result = cuCtxPushCurrent(ctx2);
+    checkCUDAError(result);
+
+    // Now the current context is ctx2
+    std::cout << "Context 2 is now current" << std::endl;
+
+    // Pop the context stack to switch back to ctx1
+    result = cuCtxPopCurrent(&currentCtx);
+    checkCUDAError(result);
+
+    // currentCtx should be ctx1 now
+    std::cout << "Context 1 is back to current" << std::endl;
+
+    // Pop the context stack to switch back to the original context
+    result = cuCtxPopCurrent(&currentCtx);
+    checkCUDAError(result);
+
+    // currentCtx should be the original context now
+    std::cout << "Original context is back to current" << std::endl;
+
+    // Cleanup
+    cuCtxDestroy(ctx1);
+    cuCtxDestroy(ctx2);
+
+    return 0;
+}

--- a/features/feature_case/context_push_n_pop/context_push_n_pop.cu
+++ b/features/feature_case/context_push_n_pop/context_push_n_pop.cu
@@ -1,3 +1,11 @@
+//===------------- context_push_n_pop.cu -------*- CUDA -*---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+//===------------------------------------------------------ -===//
 #include <cuda.h>
 #include <iostream>
 

--- a/features/feature_case/context_push_n_pop/context_push_n_pop.cu
+++ b/features/feature_case/context_push_n_pop/context_push_n_pop.cu
@@ -1,64 +1,46 @@
 #include <cuda.h>
 #include <iostream>
 
-void checkCUDAError(CUresult result) {
-    if (result != CUDA_SUCCESS) {
-        const char* errorStr;
-        cuGetErrorString(result, &errorStr);
-        std::cerr << "CUDA Error: " << errorStr << std::endl;
-        exit(EXIT_FAILURE);
-    }
-}
 
 int main() {
     CUcontext ctx1, ctx2;
     CUdevice device;
-    CUresult result;
 
     // Initialize the CUDA Driver API
-    result = cuInit(0);
-    checkCUDAError(result);
+    cuInit(0);
 
     // Get the device
-    result = cuDeviceGet(&device, 0);
-    checkCUDAError(result);
+    cuDeviceGet(&device, 0);
 
     // Create the first context
-    result = cuCtxCreate(&ctx1, 0, device);
-    checkCUDAError(result);
+    cuCtxCreate(&ctx1, 0, device);
 
     // Create the second context
-    result = cuCtxCreate(&ctx2, 0, device);
-    checkCUDAError(result);
+    cuCtxCreate(&ctx2, 0, device);
 
     // Get the current context and push it onto the stack
     CUcontext currentCtx;
-    result = cuCtxGetCurrent(&currentCtx);
-    checkCUDAError(result);
+    cuCtxGetCurrent(&currentCtx);
 
-    result = cuCtxPushCurrent(ctx1);
-    checkCUDAError(result);
+    cuCtxPushCurrent(ctx1);
 
     // Now the current context is ctx1
     std::cout << "Context 1 is now current" << std::endl;
 
     // Push the current context (ctx1) and switch to ctx2
-    result = cuCtxPushCurrent(ctx2);
-    checkCUDAError(result);
+    cuCtxPushCurrent(ctx2);
 
     // Now the current context is ctx2
     std::cout << "Context 2 is now current" << std::endl;
 
     // Pop the context stack to switch back to ctx1
-    result = cuCtxPopCurrent(&currentCtx);
-    checkCUDAError(result);
+    cuCtxPopCurrent(&currentCtx);
 
     // currentCtx should be ctx1 now
     std::cout << "Context 1 is back to current" << std::endl;
 
     // Pop the context stack to switch back to the original context
-    result = cuCtxPopCurrent(&currentCtx);
-    checkCUDAError(result);
+    cuCtxPopCurrent(&currentCtx);
 
     // currentCtx should be the original context now
     std::cout << "Original context is back to current" << std::endl;

--- a/features/feature_case/driverStreamAndEvent/driverStreamAndEvent.cu
+++ b/features/feature_case/driverStreamAndEvent/driverStreamAndEvent.cu
@@ -18,6 +18,8 @@ void callback(CUstream hStream, CUresult status, void* userData) {
   process(hStream, data, status);
 }
 
+int driverStreamQuery(void);
+
 int main(){
   CUfunction f;
   CUstream s;
@@ -61,6 +63,7 @@ int main(){
   cuStreamDestroy(s);
   cuEventDestroy(start);
   cuEventDestroy(end);
-  return 0;
+
+  return driverStreamQuery();
 }
 

--- a/features/feature_case/driverStreamAndEvent/driverStreamQuery.cu
+++ b/features/feature_case/driverStreamAndEvent/driverStreamQuery.cu
@@ -1,7 +1,7 @@
 #include <cuda.h>
 #include <iostream>
 
-int main() {
+int driverStreamQuery(void) {
     CUstream stream;
 
     // Initialize the CUDA Driver API

--- a/features/feature_case/driverStreamAndEvent/driverStreamQuery.cu
+++ b/features/feature_case/driverStreamAndEvent/driverStreamQuery.cu
@@ -1,0 +1,27 @@
+#include <cuda.h>
+#include <iostream>
+
+int main() {
+    CUstream stream;
+
+    // Initialize the CUDA Driver API
+    cuInit(0);
+
+    // Create a CUDA stream
+    cuStreamCreate(&stream, CU_STREAM_DEFAULT);
+
+    CUresult queryResult = cuStreamQuery(stream);
+
+    if (queryResult == CUDA_SUCCESS) {
+        std::cout << "Kernel execution has completed." << std::endl;
+    } else if (queryResult == CUDA_ERROR_NOT_READY) {
+        std::cout << "Kernel execution has not yet completed." << std::endl;
+    } else {
+        std::cerr << "Failed to query the stream status." << std::endl;
+    }
+
+    // Clean up resources
+    cuStreamDestroy(stream);
+
+    return 0;
+}

--- a/features/feature_case/driverStreamAndEvent/driverStreamQuery.cu
+++ b/features/feature_case/driverStreamAndEvent/driverStreamQuery.cu
@@ -1,3 +1,11 @@
+//===-------------- driverStreamQuery.cu -------*- CUDA -*---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+//===------------------------------------------------------ -===//
 #include <cuda.h>
 #include <iostream>
 

--- a/features/feature_case/peer_access_using_driver_api/peer_access_using_driver_api.cu
+++ b/features/feature_case/peer_access_using_driver_api/peer_access_using_driver_api.cu
@@ -1,0 +1,32 @@
+#include <cuda.h>
+#include <iostream>
+
+int main() {
+    CUdevice device1, device2;
+    CUcontext context1, context2;
+
+    // Initialize CUDA Driver API
+    CUresult result = cuInit(0);
+
+    cuDeviceGet(&device1, 0); // Device 0
+    cuDeviceGet(&device2, 1); // Device 1
+
+    // Create contexts for the devices
+    cuCtxCreate(&context1, 0, device1);
+    cuCtxCreate(&context2, 0, device2);
+
+    // Enable peer access between the two contexts
+    cuCtxSetCurrent(context1);
+    result = cuCtxEnablePeerAccess(context2, 0);
+    if (result != CUDA_SUCCESS) {
+        std::cerr << "Failed to enable peer access from device 0 to device 1\n";
+    }
+
+    int accessEnabled;
+    result = cuDeviceCanAccessPeer(&accessEnabled, device1, device2);
+
+    std::cout << "Peer-to-peer device access enabled.\n";
+
+    return 0;
+}
+

--- a/features/feature_case/peer_access_using_driver_api/peer_access_using_driver_api.cu
+++ b/features/feature_case/peer_access_using_driver_api/peer_access_using_driver_api.cu
@@ -1,3 +1,11 @@
+//===--- peer_access_driver_api_tests.cu -------*- CUDA -*---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+//===------------------------------------------------------ -===//
 #include <cuda.h>
 #include <iostream>
 

--- a/features/features.xml
+++ b/features/features.xml
@@ -355,5 +355,7 @@
     <test testName="matmul" configFile="config/TEMPLATE_cublasLt.xml" />
     <test testName="transform" configFile="config/TEMPLATE_cublasLt.xml" />
     <test testName="graphics_interop_d3d11" configFile="config/TEMPLATE_cudaGraphics_Interop.xml" />
+    <test testName="peer_access_using_driver_api" configFile="config/TEMPLATE_peer_access_using_driver_api.xml" />
+    <test testName="context_push_n_pop" configFile="config/TEMPLATE_context_push_n_pop.xml" />
   </tests>
 </suite>

--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -61,7 +61,7 @@ exec_tests = ['asm', 'asm_bar', 'asm_mem', 'asm_atom', 'asm_arith', 'asm_vinst',
               'thrust_swap_ranges', 'thrust_uninitialized_fill_n', 'thrust_equal', 'system_atomic', 'thrust_detail_types',
               'operator_eq', 'operator_neq', 'operator_lege', 'thrust_system', 'thrust_reverse_copy',
               'thrust_device_new_delete', 'thrust_temporary_buffer', 'thrust_malloc_free', 'codepin', 'thrust_unique_count',
-              'thrust_advance_trans_op_itr', 'cuda_stream_query', "matmul", "transform",
+              'thrust_advance_trans_op_itr', 'cuda_stream_query', "matmul", "transform", "context_push_n_pop",
               "graphics_interop_d3d11"]
 
 occupancy_calculation_exper = ['occupancy_calculation']


### PR DESCRIPTION
As described in the title adding end-to-end test for the mentioned API.