### PR TITLE
Exclusing syclcompat opt set

### DIFF
--- a/features/config/TEMPLATE_cudaGraphics_Interop.xml
+++ b/features/config/TEMPLATE_cudaGraphics_Interop.xml
@@ -8,5 +8,7 @@
     <rules>
         <platformRule OSFamily="Linux" runOnThisPlatform="false"/>
         <platformRule OSFamily="Windows" kit="CUDA9.2" kitRange="OLDER" runOnThisPlatform="false"/>
+        <optlevelRule excludeOptlevelNameString="cpu"/>
+        <optlevelRule excludeOptlevelNameString="syclcompat"/>
     </rules>
 </test>


### PR DESCRIPTION
Excluded syclcompat opt set due to no support for D3D11 migration in it