### PR TITLE
[SYCLomatic] Disable testing context handling APIs with SYCLcompact

### DIFF
--- a/features/config/TEMPLATE_context_push_n_pop.xml
+++ b/features/config/TEMPLATE_context_push_n_pop.xml
@@ -5,5 +5,7 @@
     <files>
         <file path="feature_case/context_push_n_pop/${testName}.cu" />
     </files>
-    <rules />
+    <rules>
+        <optlevelRule excludeOptlevelNameString="syclcompat" />
+    </rules>
 </test>


### PR DESCRIPTION
Migration of `cuCtxCreate` is dependent on helper function and it's yet to be supported in SYCLcompact. Disable testing the dependent API migration `cuCtxPushCurrent` and `cuCtxPopCurrent`.

Signed-off by: [Deepak Raj H R](deepak.raj.h.r@intel.com)