### PR TITLE
[SYCLomatic #2476] Add test for the migration of PTX instruction "membar" with level on .cta .gl and sys and "fence" with thread level on scope '.cta', '.gpu' and '.sys'

### DIFF
--- a/features/feature_case/asm/asm_membar_fence.cu
+++ b/features/feature_case/asm/asm_membar_fence.cu
@@ -22,7 +22,7 @@
 
 __global__ void producer_kernel_membar_gl(int *data, int *flag) {
   if (threadIdx.x == 0) {
-    *data = 42;
+    *data = 0xABCD;
 
     asm volatile("membar.gl;" : : : "memory");
     *flag = 1;
@@ -41,7 +41,7 @@ __global__ void consumer_kernel_membar_gl(int *data, int *flag, int *output) {
 
 __global__ void producer_kernel_membar_cta(int *data, int *flag) {
   if (threadIdx.x == 0) {
-    *data = 42;
+    *data = 0xABCD;
 
     asm volatile("membar.cta;" : : : "memory");
     *flag = 1;
@@ -60,7 +60,7 @@ __global__ void consumer_kernel_membar_cta(int *data, int *flag, int *output) {
 
 __global__ void producer_kernel_membar_sys(int *data, int *flag) {
   if (threadIdx.x == 0) {
-    *data = 42;
+    *data = 0xABCD;
 
     asm volatile("membar.sys;" : : : "memory");
     *flag = 1;
@@ -79,7 +79,7 @@ __global__ void consumer_kernel_membar_sys(int *data, int *flag, int *output) {
 
 __global__ void producer_kernel_fence_sc_cta(int *data, int *flag) {
   if (threadIdx.x == 0) {
-    *data = 42;
+    *data = 0xABCD;
 
     asm volatile("fence.sc.cta; " : : : "memory");
     *flag = 1;
@@ -99,7 +99,7 @@ __global__ void consumer_kernel_fence_sc_cta(int *data, int *flag,
 
 __global__ void producer_kernel_fence_sc_gpu(int *data, int *flag) {
   if (threadIdx.x == 0) {
-    *data = 42;
+    *data = 0xABCD;
 
     asm volatile("fence.sc.gpu; " : : : "memory");
     *flag = 1;
@@ -119,7 +119,7 @@ __global__ void consumer_kernel_fence_sc_gpu(int *data, int *flag,
 
 __global__ void producer_kernel_fence_sc_sys(int *data, int *flag) {
   if (threadIdx.x == 0) {
-    *data = 42;
+    *data = 0xABCD;
 
     asm volatile("fence.sc.sys; " : : : "memory");
     *flag = 1;
@@ -139,7 +139,7 @@ __global__ void consumer_kernel_fence_sc_sys(int *data, int *flag,
 
 __global__ void producer_kernel_fence_acq_rel_cta(int *data, int *flag) {
   if (threadIdx.x == 0) {
-    *data = 42;
+    *data = 0xABCD;
 
     asm volatile("fence.acq_rel.cta; " : : : "memory");
     *flag = 1;
@@ -159,7 +159,7 @@ __global__ void consumer_kernel_fence_acq_rel_cta(int *data, int *flag,
 
 __global__ void producer_kernel_fence_acq_rel_gpu(int *data, int *flag) {
   if (threadIdx.x == 0) {
-    *data = 42;
+    *data = 0xABCD;
 
     asm volatile("fence.acq_rel.cta; " : : : "memory");
     *flag = 1;
@@ -179,7 +179,7 @@ __global__ void consumer_kernel_fence_acq_rel_gpu(int *data, int *flag,
 
 __global__ void producer_kernel_fence_acq_rel_sys(int *data, int *flag) {
   if (threadIdx.x == 0) {
-    *data = 42;
+    *data = 0xABCD;
 
     asm volatile("fence.acq_rel.sys; " : : : "memory");
     *flag = 1;
@@ -217,12 +217,9 @@ bool kernel_membar_gl_test() {
   cudaFree(d_flag);
   cudaFree(d_output);
 
-  if (h_output == 42) {
-    printf("Verification passed! Consumer read the correct data: %d\n",
-           h_output);
+  if (h_output == 0xABCD) {
     return true;
   } else {
-    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
     return false;
   }
 }
@@ -247,12 +244,9 @@ bool kernel_membar_sys_test() {
   cudaFree(d_flag);
   cudaFree(d_output);
 
-  if (h_output == 42) {
-    printf("Verification passed! Consumer read the correct data: %d\n",
-           h_output);
+  if (h_output == 0xABCD) {
     return true;
   } else {
-    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
     return false;
   }
 }
@@ -277,12 +271,9 @@ bool kernel_membar_cta_test() {
   cudaFree(d_flag);
   cudaFree(d_output);
 
-  if (h_output == 42) {
-    printf("Verification passed! Consumer read the correct data: %d\n",
-           h_output);
+  if (h_output == 0xABCD) {
     return true;
   } else {
-    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
     return false;
   }
 }
@@ -307,12 +298,9 @@ bool kernel_kernel_fence_sc_cta() {
   cudaFree(d_flag);
   cudaFree(d_output);
 
-  if (h_output == 42) {
-    printf("Verification passed! Consumer read the correct data: %d\n",
-           h_output);
+  if (h_output == 0xABCD) {
     return true;
   } else {
-    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
     return false;
   }
 }
@@ -337,12 +325,9 @@ bool kernel_kernel_fence_sc_device() {
   cudaFree(d_flag);
   cudaFree(d_output);
 
-  if (h_output == 42) {
-    printf("Verification passed! Consumer read the correct data: %d\n",
-           h_output);
+  if (h_output == 0xABCD) {
     return true;
   } else {
-    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
     return false;
   }
 }
@@ -367,12 +352,9 @@ bool kernel_kernel_fence_sc_sys() {
   cudaFree(d_flag);
   cudaFree(d_output);
 
-  if (h_output == 42) {
-    printf("Verification passed! Consumer read the correct data: %d\n",
-           h_output);
+  if (h_output == 0xABCD) {
     return true;
   } else {
-    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
     return false;
   }
 }
@@ -397,12 +379,9 @@ bool kernel_fence_acq_rel_cta() {
   cudaFree(d_flag);
   cudaFree(d_output);
 
-  if (h_output == 42) {
-    printf("Verification passed! Consumer read the correct data: %d\n",
-           h_output);
+  if (h_output == 0xABCD) {
     return true;
   } else {
-    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
     return false;
   }
 }
@@ -427,12 +406,9 @@ bool kernel_fence_acq_rel_device() {
   cudaFree(d_flag);
   cudaFree(d_output);
 
-  if (h_output == 42) {
-    printf("Verification passed! Consumer read the correct data: %d\n",
-           h_output);
+  if (h_output == 0xABCD) {
     return true;
   } else {
-    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
     return false;
   }
 }
@@ -457,12 +433,9 @@ bool kernel_fence_acq_rel_sys() {
   cudaFree(d_flag);
   cudaFree(d_output);
 
-  if (h_output == 42) {
-    printf("Verification passed! Consumer read the correct data: %d\n",
-           h_output);
+  if (h_output == 0xABCD) {
     return true;
   } else {
-    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
     return false;
   }
 }

--- a/features/feature_case/asm/asm_membar_fence.cu
+++ b/features/feature_case/asm/asm_membar_fence.cu
@@ -1,0 +1,484 @@
+// ===------- asm_membar_fence.cu ------------------------- *- CUDA -* ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===---------------------------------------------------------------------===//
+
+#include <cuda_runtime.h>
+#include <stdio.h>
+
+#define TEST(FN)                                                               \
+  {                                                                            \
+    if (FN()) {                                                                \
+      printf("Test " #FN " PASS\n");                                           \
+    } else {                                                                   \
+      printf("Test " #FN " FAIL\n");                                           \
+      return 1;                                                                \
+    }                                                                          \
+  }
+
+__global__ void producer_kernel_membar_gl(int *data, int *flag) {
+  if (threadIdx.x == 0) {
+    *data = 42;
+
+    asm volatile("membar.gl;" : : : "memory");
+    *flag = 1;
+  }
+}
+
+__global__ void consumer_kernel_membar_gl(int *data, int *flag, int *output) {
+  if (threadIdx.x == 0) {
+    while (atomicAdd(flag, 0) == 0) {
+    }
+
+    asm volatile("membar.gl;" : : : "memory");
+    *output = *data;
+  }
+}
+
+__global__ void producer_kernel_membar_cta(int *data, int *flag) {
+  if (threadIdx.x == 0) {
+    *data = 42;
+
+    asm volatile("membar.cta;" : : : "memory");
+    *flag = 1;
+  }
+}
+
+__global__ void consumer_kernel_membar_cta(int *data, int *flag, int *output) {
+  if (threadIdx.x == 0) {
+    while (atomicAdd(flag, 0) == 0) {
+    }
+
+    asm volatile("membar.cta;" : : : "memory");
+    *output = *data;
+  }
+}
+
+__global__ void producer_kernel_membar_sys(int *data, int *flag) {
+  if (threadIdx.x == 0) {
+    *data = 42;
+
+    asm volatile("membar.sys;" : : : "memory");
+    *flag = 1;
+  }
+}
+
+__global__ void consumer_kernel_membar_sys(int *data, int *flag, int *output) {
+  if (threadIdx.x == 0) {
+    while (atomicAdd(flag, 0) == 0) {
+    }
+
+    asm volatile("membar.sys;" : : : "memory");
+    *output = *data;
+  }
+}
+
+__global__ void producer_kernel_fence_sc_cta(int *data, int *flag) {
+  if (threadIdx.x == 0) {
+    *data = 42;
+
+    asm volatile("fence.sc.cta; " : : : "memory");
+    *flag = 1;
+  }
+}
+
+__global__ void consumer_kernel_fence_sc_cta(int *data, int *flag,
+                                             int *output) {
+  if (threadIdx.x == 0) {
+    while (atomicAdd(flag, 0) == 0) {
+    }
+
+    asm volatile("fence.sc.cta; " : : : "memory");
+    *output = *data;
+  }
+}
+
+__global__ void producer_kernel_fence_sc_gpu(int *data, int *flag) {
+  if (threadIdx.x == 0) {
+    *data = 42;
+
+    asm volatile("fence.sc.gpu; " : : : "memory");
+    *flag = 1;
+  }
+}
+
+__global__ void consumer_kernel_fence_sc_gpu(int *data, int *flag,
+                                             int *output) {
+  if (threadIdx.x == 0) {
+    while (atomicAdd(flag, 0) == 0) {
+    }
+
+    asm volatile("fence.sc.gpu; " : : : "memory");
+    *output = *data;
+  }
+}
+
+__global__ void producer_kernel_fence_sc_sys(int *data, int *flag) {
+  if (threadIdx.x == 0) {
+    *data = 42;
+
+    asm volatile("fence.sc.sys; " : : : "memory");
+    *flag = 1;
+  }
+}
+
+__global__ void consumer_kernel_fence_sc_sys(int *data, int *flag,
+                                             int *output) {
+  if (threadIdx.x == 0) {
+    while (atomicAdd(flag, 0) == 0) {
+    }
+
+    asm volatile("fence.sc.sys; " : : : "memory");
+    *output = *data;
+  }
+}
+
+__global__ void producer_kernel_fence_acq_rel_cta(int *data, int *flag) {
+  if (threadIdx.x == 0) {
+    *data = 42;
+
+    asm volatile("fence.acq_rel.cta; " : : : "memory");
+    *flag = 1;
+  }
+}
+
+__global__ void consumer_kernel_fence_acq_rel_cta(int *data, int *flag,
+                                                  int *output) {
+  if (threadIdx.x == 0) {
+    while (atomicAdd(flag, 0) == 0) {
+    }
+
+    asm volatile("fence.acq_rel.cta; " : : : "memory");
+    *output = *data;
+  }
+}
+
+__global__ void producer_kernel_fence_acq_rel_gpu(int *data, int *flag) {
+  if (threadIdx.x == 0) {
+    *data = 42;
+
+    asm volatile("fence.acq_rel.cta; " : : : "memory");
+    *flag = 1;
+  }
+}
+
+__global__ void consumer_kernel_fence_acq_rel_gpu(int *data, int *flag,
+                                                  int *output) {
+  if (threadIdx.x == 0) {
+    while (atomicAdd(flag, 0) == 0) {
+    }
+
+    asm volatile("fence.acq_rel.gpu; " : : : "memory");
+    *output = *data;
+  }
+}
+
+__global__ void producer_kernel_fence_acq_rel_sys(int *data, int *flag) {
+  if (threadIdx.x == 0) {
+    *data = 42;
+
+    asm volatile("fence.acq_rel.sys; " : : : "memory");
+    *flag = 1;
+  }
+}
+
+__global__ void consumer_kernel_fence_acq_rel_sys(int *data, int *flag,
+                                                  int *output) {
+  if (threadIdx.x == 0) {
+    while (atomicAdd(flag, 0) == 0) {
+    }
+
+    asm volatile("fence.acq_rel.sys; " : : : "memory");
+    *output = *data;
+  }
+}
+
+bool kernel_membar_gl_test() {
+  int *d_data, *d_flag, *d_output;
+  int h_data = 0, h_flag = 0, h_output = 0;
+
+  cudaMalloc(&d_data, sizeof(int));
+  cudaMalloc(&d_flag, sizeof(int));
+  cudaMalloc(&d_output, sizeof(int));
+
+  cudaMemcpy(d_data, &h_data, sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_flag, &h_flag, sizeof(int), cudaMemcpyHostToDevice);
+
+  producer_kernel_membar_gl<<<1, 32>>>(d_data, d_flag);
+  consumer_kernel_membar_gl<<<1, 32>>>(d_data, d_flag, d_output);
+
+  cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_data);
+  cudaFree(d_flag);
+  cudaFree(d_output);
+
+  if (h_output == 42) {
+    printf("Verification passed! Consumer read the correct data: %d\n",
+           h_output);
+    return true;
+  } else {
+    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
+    return false;
+  }
+}
+
+bool kernel_membar_sys_test() {
+  int *d_data, *d_flag, *d_output;
+  int h_data = 0, h_flag = 0, h_output = 0;
+
+  cudaMalloc(&d_data, sizeof(int));
+  cudaMalloc(&d_flag, sizeof(int));
+  cudaMalloc(&d_output, sizeof(int));
+
+  cudaMemcpy(d_data, &h_data, sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_flag, &h_flag, sizeof(int), cudaMemcpyHostToDevice);
+
+  producer_kernel_membar_sys<<<1, 32>>>(d_data, d_flag);
+  consumer_kernel_membar_sys<<<1, 32>>>(d_data, d_flag, d_output);
+
+  cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_data);
+  cudaFree(d_flag);
+  cudaFree(d_output);
+
+  if (h_output == 42) {
+    printf("Verification passed! Consumer read the correct data: %d\n",
+           h_output);
+    return true;
+  } else {
+    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
+    return false;
+  }
+}
+
+bool kernel_membar_cta_test() {
+  int *d_data, *d_flag, *d_output;
+  int h_data = 0, h_flag = 0, h_output = 0;
+
+  cudaMalloc(&d_data, sizeof(int));
+  cudaMalloc(&d_flag, sizeof(int));
+  cudaMalloc(&d_output, sizeof(int));
+
+  cudaMemcpy(d_data, &h_data, sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_flag, &h_flag, sizeof(int), cudaMemcpyHostToDevice);
+
+  producer_kernel_membar_cta<<<1, 32>>>(d_data, d_flag);
+  consumer_kernel_membar_cta<<<1, 32>>>(d_data, d_flag, d_output);
+
+  cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_data);
+  cudaFree(d_flag);
+  cudaFree(d_output);
+
+  if (h_output == 42) {
+    printf("Verification passed! Consumer read the correct data: %d\n",
+           h_output);
+    return true;
+  } else {
+    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
+    return false;
+  }
+}
+
+bool kernel_kernel_fence_sc_cta() {
+  int *d_data, *d_flag, *d_output;
+  int h_data = 0, h_flag = 0, h_output = 0;
+
+  cudaMalloc(&d_data, sizeof(int));
+  cudaMalloc(&d_flag, sizeof(int));
+  cudaMalloc(&d_output, sizeof(int));
+
+  cudaMemcpy(d_data, &h_data, sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_flag, &h_flag, sizeof(int), cudaMemcpyHostToDevice);
+
+  producer_kernel_fence_sc_cta<<<1, 32>>>(d_data, d_flag);
+  consumer_kernel_fence_sc_cta<<<1, 32>>>(d_data, d_flag, d_output);
+
+  cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_data);
+  cudaFree(d_flag);
+  cudaFree(d_output);
+
+  if (h_output == 42) {
+    printf("Verification passed! Consumer read the correct data: %d\n",
+           h_output);
+    return true;
+  } else {
+    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
+    return false;
+  }
+}
+
+bool kernel_kernel_fence_sc_device() {
+  int *d_data, *d_flag, *d_output;
+  int h_data = 0, h_flag = 0, h_output = 0;
+
+  cudaMalloc(&d_data, sizeof(int));
+  cudaMalloc(&d_flag, sizeof(int));
+  cudaMalloc(&d_output, sizeof(int));
+
+  cudaMemcpy(d_data, &h_data, sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_flag, &h_flag, sizeof(int), cudaMemcpyHostToDevice);
+
+  producer_kernel_fence_sc_gpu<<<1, 32>>>(d_data, d_flag);
+  consumer_kernel_fence_sc_gpu<<<1, 32>>>(d_data, d_flag, d_output);
+
+  cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_data);
+  cudaFree(d_flag);
+  cudaFree(d_output);
+
+  if (h_output == 42) {
+    printf("Verification passed! Consumer read the correct data: %d\n",
+           h_output);
+    return true;
+  } else {
+    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
+    return false;
+  }
+}
+
+bool kernel_kernel_fence_sc_sys() {
+  int *d_data, *d_flag, *d_output;
+  int h_data = 0, h_flag = 0, h_output = 0;
+
+  cudaMalloc(&d_data, sizeof(int));
+  cudaMalloc(&d_flag, sizeof(int));
+  cudaMalloc(&d_output, sizeof(int));
+
+  cudaMemcpy(d_data, &h_data, sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_flag, &h_flag, sizeof(int), cudaMemcpyHostToDevice);
+
+  producer_kernel_fence_sc_sys<<<1, 32>>>(d_data, d_flag);
+  consumer_kernel_fence_sc_sys<<<1, 32>>>(d_data, d_flag, d_output);
+
+  cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_data);
+  cudaFree(d_flag);
+  cudaFree(d_output);
+
+  if (h_output == 42) {
+    printf("Verification passed! Consumer read the correct data: %d\n",
+           h_output);
+    return true;
+  } else {
+    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
+    return false;
+  }
+}
+
+bool kernel_fence_acq_rel_cta() {
+  int *d_data, *d_flag, *d_output;
+  int h_data = 0, h_flag = 0, h_output = 0;
+
+  cudaMalloc(&d_data, sizeof(int));
+  cudaMalloc(&d_flag, sizeof(int));
+  cudaMalloc(&d_output, sizeof(int));
+
+  cudaMemcpy(d_data, &h_data, sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_flag, &h_flag, sizeof(int), cudaMemcpyHostToDevice);
+
+  producer_kernel_fence_acq_rel_cta<<<1, 32>>>(d_data, d_flag);
+  consumer_kernel_fence_acq_rel_cta<<<1, 32>>>(d_data, d_flag, d_output);
+
+  cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_data);
+  cudaFree(d_flag);
+  cudaFree(d_output);
+
+  if (h_output == 42) {
+    printf("Verification passed! Consumer read the correct data: %d\n",
+           h_output);
+    return true;
+  } else {
+    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
+    return false;
+  }
+}
+
+bool kernel_fence_acq_rel_device() {
+  int *d_data, *d_flag, *d_output;
+  int h_data = 0, h_flag = 0, h_output = 0;
+
+  cudaMalloc(&d_data, sizeof(int));
+  cudaMalloc(&d_flag, sizeof(int));
+  cudaMalloc(&d_output, sizeof(int));
+
+  cudaMemcpy(d_data, &h_data, sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_flag, &h_flag, sizeof(int), cudaMemcpyHostToDevice);
+
+  producer_kernel_fence_acq_rel_cta<<<1, 32>>>(d_data, d_flag);
+  consumer_kernel_fence_acq_rel_cta<<<1, 32>>>(d_data, d_flag, d_output);
+
+  cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_data);
+  cudaFree(d_flag);
+  cudaFree(d_output);
+
+  if (h_output == 42) {
+    printf("Verification passed! Consumer read the correct data: %d\n",
+           h_output);
+    return true;
+  } else {
+    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
+    return false;
+  }
+}
+
+bool kernel_fence_acq_rel_sys() {
+  int *d_data, *d_flag, *d_output;
+  int h_data = 0, h_flag = 0, h_output = 0;
+
+  cudaMalloc(&d_data, sizeof(int));
+  cudaMalloc(&d_flag, sizeof(int));
+  cudaMalloc(&d_output, sizeof(int));
+
+  cudaMemcpy(d_data, &h_data, sizeof(int), cudaMemcpyHostToDevice);
+  cudaMemcpy(d_flag, &h_flag, sizeof(int), cudaMemcpyHostToDevice);
+
+  producer_kernel_fence_acq_rel_sys<<<1, 32>>>(d_data, d_flag);
+  consumer_kernel_fence_acq_rel_sys<<<1, 32>>>(d_data, d_flag, d_output);
+
+  cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_data);
+  cudaFree(d_flag);
+  cudaFree(d_output);
+
+  if (h_output == 42) {
+    printf("Verification passed! Consumer read the correct data: %d\n",
+           h_output);
+    return true;
+  } else {
+    printf("Verification failed. Consumer read incorrect data: %d\n", h_output);
+    return false;
+  }
+}
+
+int main() {
+  TEST(kernel_membar_gl_test);
+  TEST(kernel_membar_cta_test);
+  TEST(kernel_membar_sys_test);
+
+  TEST(kernel_kernel_fence_sc_cta);
+  TEST(kernel_kernel_fence_sc_device);
+  TEST(kernel_kernel_fence_sc_sys);
+
+  TEST(kernel_fence_acq_rel_cta);
+  TEST(kernel_fence_acq_rel_device);
+  TEST(kernel_fence_acq_rel_sys);
+
+  return 0;
+}

--- a/features/feature_case/asm/asm_membar_fence.cu
+++ b/features/feature_case/asm/asm_membar_fence.cu
@@ -210,7 +210,7 @@ bool kernel_membar_gl_test() {
 
   producer_kernel_membar_gl<<<1, 32>>>(d_data, d_flag);
   consumer_kernel_membar_gl<<<1, 32>>>(d_data, d_flag, d_output);
-
+  cudaDeviceSynchronize();
   cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
 
   cudaFree(d_data);
@@ -237,7 +237,7 @@ bool kernel_membar_sys_test() {
 
   producer_kernel_membar_sys<<<1, 32>>>(d_data, d_flag);
   consumer_kernel_membar_sys<<<1, 32>>>(d_data, d_flag, d_output);
-
+  cudaDeviceSynchronize();
   cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
 
   cudaFree(d_data);
@@ -264,7 +264,7 @@ bool kernel_membar_cta_test() {
 
   producer_kernel_membar_cta<<<1, 32>>>(d_data, d_flag);
   consumer_kernel_membar_cta<<<1, 32>>>(d_data, d_flag, d_output);
-
+  cudaDeviceSynchronize();
   cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
 
   cudaFree(d_data);
@@ -291,7 +291,7 @@ bool kernel_kernel_fence_sc_cta() {
 
   producer_kernel_fence_sc_cta<<<1, 32>>>(d_data, d_flag);
   consumer_kernel_fence_sc_cta<<<1, 32>>>(d_data, d_flag, d_output);
-
+  cudaDeviceSynchronize();
   cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
 
   cudaFree(d_data);
@@ -318,7 +318,7 @@ bool kernel_kernel_fence_sc_device() {
 
   producer_kernel_fence_sc_gpu<<<1, 32>>>(d_data, d_flag);
   consumer_kernel_fence_sc_gpu<<<1, 32>>>(d_data, d_flag, d_output);
-
+  cudaDeviceSynchronize();
   cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
 
   cudaFree(d_data);
@@ -345,7 +345,7 @@ bool kernel_kernel_fence_sc_sys() {
 
   producer_kernel_fence_sc_sys<<<1, 32>>>(d_data, d_flag);
   consumer_kernel_fence_sc_sys<<<1, 32>>>(d_data, d_flag, d_output);
-
+  cudaDeviceSynchronize();
   cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
 
   cudaFree(d_data);
@@ -372,7 +372,7 @@ bool kernel_fence_acq_rel_cta() {
 
   producer_kernel_fence_acq_rel_cta<<<1, 32>>>(d_data, d_flag);
   consumer_kernel_fence_acq_rel_cta<<<1, 32>>>(d_data, d_flag, d_output);
-
+  cudaDeviceSynchronize();
   cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
 
   cudaFree(d_data);
@@ -399,7 +399,7 @@ bool kernel_fence_acq_rel_device() {
 
   producer_kernel_fence_acq_rel_cta<<<1, 32>>>(d_data, d_flag);
   consumer_kernel_fence_acq_rel_cta<<<1, 32>>>(d_data, d_flag, d_output);
-
+  cudaDeviceSynchronize();
   cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
 
   cudaFree(d_data);
@@ -426,7 +426,7 @@ bool kernel_fence_acq_rel_sys() {
 
   producer_kernel_fence_acq_rel_sys<<<1, 32>>>(d_data, d_flag);
   consumer_kernel_fence_acq_rel_sys<<<1, 32>>>(d_data, d_flag, d_output);
-
+  cudaDeviceSynchronize();
   cudaMemcpy(&h_output, d_output, sizeof(int), cudaMemcpyDeviceToHost);
 
   cudaFree(d_data);

--- a/features/features.xml
+++ b/features/features.xml
@@ -14,6 +14,7 @@
     <test testName="asm_shfl_sync" configFile="config/TEMPLATE_asm_excluding_syclcompat.xml" />
     <test testName="asm_shfl" configFile="config/TEMPLATE_asm_excluding_syclcompat.xml" />
     <test testName="asm_shfl_sync_with_exp" configFile="config/TEMPLATE_asm_excluding_syclcompat.xml" />
+    <test testName="asm_membar_fence" configFile="config/TEMPLATE_asm_excluding_syclcompat.xml" />
     <test testName="asm_arith" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_optimize" configFile="config/TEMPLATE_asm.xml" />
     <test testName="thrust-op" configFile="config/TEMPLATE_thrust_op.xml" />

--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -62,7 +62,7 @@ exec_tests = ['asm', 'asm_bar', 'asm_mem', 'asm_atom', 'asm_arith', 'asm_vinst',
               'operator_eq', 'operator_neq', 'operator_lege', 'thrust_system', 'thrust_reverse_copy',
               'thrust_device_new_delete', 'thrust_temporary_buffer', 'thrust_malloc_free', 'codepin', 'thrust_unique_count',
               'thrust_advance_trans_op_itr', 'cuda_stream_query', "matmul", "transform",  "context_push_n_pop",
-              "graphics_interop_d3d11", 'graph', 'asm_shfl', 'asm_shfl_sync', 'asm_shfl_sync_with_exp']
+              "graphics_interop_d3d11", 'graph', 'asm_shfl', 'asm_shfl_sync', 'asm_shfl_sync_with_exp', 'asm_membar_fence']
 
 occupancy_calculation_exper = ['occupancy_calculation']
 


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>
