### PR TITLE
[SYCLomtic] Skip CUDA header file versions before 11.0 for asm tests

### DIFF
--- a/features/config/TEMPLATE_asm.xml
+++ b/features/config/TEMPLATE_asm.xml
@@ -6,6 +6,8 @@
         <file path="feature_case/asm/${testName}.cu" />
     </files>
     <rules>
+        <platformRule OSFamily="Linux" kit="CUDA11.0" kitRange="OLDER" runOnThisPlatform="false"/>
+        <platformRule OSFamily="Windows" kit="CUDA11.0" kitRange="OLDER" runOnThisPlatform="false"/>
         <optlevelRule excludeOptlevelNameString="cuda" />
         <optlevelRule GPUFeature="NOT double" excludeOptlevelNameString="gpu" />
     </rules>

--- a/features/config/TEMPLATE_asm_excluding_syclcompat.xml
+++ b/features/config/TEMPLATE_asm_excluding_syclcompat.xml
@@ -6,6 +6,8 @@
         <file path="feature_case/asm/${testName}.cu" />
     </files>
     <rules>
+        <platformRule OSFamily="Linux" kit="CUDA11.0" kitRange="OLDER" runOnThisPlatform="false"/>
+        <platformRule OSFamily="Windows" kit="CUDA11.0" kitRange="OLDER" runOnThisPlatform="false"/>
         <optlevelRule excludeOptlevelNameString="cuda" />
         <optlevelRule GPUFeature="NOT double" excludeOptlevelNameString="gpu" />
         <optlevelRule excludeOptlevelNameString="syclcompat" />


### PR DESCRIPTION
Signed-off-by: chenwei.sun <chenwei.sun@intel.com>