### PR TITLE
[Graphics Interop][#2610] Removed CUgraphics_resource type from unsupported-type-function test

### DIFF
--- a/behavior_tests/src/bt-unsupported-type-function/test.cu
+++ b/behavior_tests/src/bt-unsupported-type-function/test.cu
@@ -24,8 +24,6 @@ int main(int argc, char **argv) {
 
     CUgraphNode cugn;
 
-    CUgraphicsResource cugr;
-
     nvmlDevice_t nvmld;
 
     nvmlReturn_t nvmlr;


### PR DESCRIPTION
As [PR#2610](https://github.com/oneapi-src/SYCLomatic/pull/2610) is merged, CUgraphics_resource is removed from unsupported-type-function test