### PR TITLE
[SYCLomatic] Fix compilation failure due to C++ version

### DIFF
--- a/help_function/src/multi_definition_test/Makefile
+++ b/help_function/src/multi_definition_test/Makefile
@@ -37,10 +37,10 @@ $(TARGET_0): $(OBJS_0)
 	$(CC) -o $@ $^ $(LIB) 
 
 $(TARGET_0_OBJ_0):$(TARGET_0_SRC_0)
-	c++ -c ${TARGET_0_SRC_0} -o ${TARGET_0_OBJ_0} $(TARGET_0_FLAG_0)
+	$(CC) -c ${TARGET_0_SRC_0} -o ${TARGET_0_OBJ_0} $(TARGET_0_FLAG_0)
 
 $(TARGET_0_OBJ_1):$(TARGET_0_SRC_1)
-	c++ -c ${TARGET_0_SRC_1} -o ${TARGET_0_OBJ_1} $(TARGET_0_FLAG_1)
+	$(CC) -c ${TARGET_0_SRC_1} -o ${TARGET_0_OBJ_1} $(TARGET_0_FLAG_1)
 
 clean:
 	rm -f  ${OBJS_0} $(TARGET)


### PR DESCRIPTION
```
c++ -c ./main.cpp -o ./main.o -Iinclude -Iinclude/sycl
In file included from include/sycl/access/access.hpp:11:0,
                 from include/sycl/accessor.hpp:11,
                 from include/sycl/detail/core.hpp:21,
                 from include/sycl/sycl.hpp:25,
                 from include/dpct/device.hpp:22,
                 from ./main.cpp:11:
bin/../include/sycl/detail/defines_elementary.hpp:90:1: error: static assertion failed: DPCPP does not support C++ version earlier than C++17. static_assert(__cplusplus >= 201703L,
 ^~~~~~~~~~~~~
```
Use the correct compiler.