### PR TITLE
[SYCLomatic #2769] Add E2E test for migration of PTX instruction ld.cg.global.v2.s16 and ld.cg.global.v4.s16

### DIFF
--- a/features/feature_case/asm/asm_ld.cu
+++ b/features/feature_case/asm/asm_ld.cu
@@ -1,0 +1,95 @@
+// ====------ asm_ld.cu ----------------------------------- *- CUDA -* ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===---------------------------------------------------------------------===//
+
+#include <cuda_runtime.h>
+
+#define TEST(FN)                                                               \
+  {                                                                            \
+    if (FN()) {                                                                \
+      printf("Test " #FN " PASS\n");                                           \
+    } else {                                                                   \
+      printf("Test " #FN " FAIL\n");                                           \
+      return 1;                                                                \
+    }                                                                          \
+  }
+
+__device__ inline void load_global_short4(short4 &a, const short4 *addr) {
+  short x, y, z, w;
+  asm("ld.cg.global.v4.s16 {%0, %1, %2, %3}, [%4+0];"
+      : "=h"(x), "=h"(y), "=h"(z), "=h"(w)
+      : "l"(addr));
+  a.x = x;
+  a.y = y;
+  a.z = z;
+  a.w = w;
+}
+
+__global__ void test_kernel(short4 *d_out, const short4 *d_in) {
+  short4 val;
+  load_global_short4(val, d_in);
+  *d_out = val;
+}
+
+__device__ inline void load_global_short2(short2 &a, const short2 *addr) {
+  short x, y, z, w;
+  asm("ld.cg.global.v2.s16 {%0, %1}, [%2+0];" : "=h"(x), "=h"(y) : "l"(addr));
+  a.x = x;
+  a.y = y;
+}
+
+__global__ void test_kernel(short2 *d_out, const short2 *d_in) {
+  short2 val;
+  load_global_short2(val, d_in);
+  *d_out = val;
+}
+
+bool test_1() {
+  short4 h_in = {1, 2, 3, 4};
+  short4 h_out;
+  short4 *d_in, *d_out;
+
+  cudaMalloc(&d_in, sizeof(short4));
+  cudaMalloc(&d_out, sizeof(short4));
+  cudaMemcpy(d_in, &h_in, sizeof(short4), cudaMemcpyHostToDevice);
+
+  test_kernel<<<1, 1>>>(d_out, d_in);
+  cudaMemcpy(&h_out, d_out, sizeof(short4), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_in);
+  cudaFree(d_out);
+
+  return (h_out.x == h_in.x && h_out.y == h_in.y && h_out.z == h_in.z &&
+          h_out.w == h_in.w)
+             ? true
+             : false;
+}
+
+bool test_2() {
+  short2 h_in = {1, 2};
+  short2 h_out;
+  short2 *d_in, *d_out;
+
+  cudaMalloc(&d_in, sizeof(short2));
+  cudaMalloc(&d_out, sizeof(short2));
+  cudaMemcpy(d_in, &h_in, sizeof(short2), cudaMemcpyHostToDevice);
+
+  test_kernel<<<1, 1>>>(d_out, d_in);
+  cudaMemcpy(&h_out, d_out, sizeof(short2), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_in);
+  cudaFree(d_out);
+
+  return (h_out.x == h_in.x && h_out.y == h_in.y) ? true : false;
+}
+
+int main() {
+  TEST(test_1);
+  TEST(test_2);
+  return 0;
+}

--- a/features/features.xml
+++ b/features/features.xml
@@ -21,6 +21,7 @@
     <test testName="asm_optimize" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_cp" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_st" configFile="config/TEMPLATE_asm.xml" />
+    <test testName="asm_ld" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_brkpt" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_sub" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_add" configFile="config/TEMPLATE_asm.xml" />

--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -63,7 +63,7 @@ exec_tests = ['asm', 'asm_bar', 'asm_mem', 'asm_atom', 'asm_arith', 'asm_vinst',
               'thrust_device_new_delete', 'thrust_temporary_buffer', 'thrust_malloc_free', 'codepin', 'thrust_unique_count',
               'thrust_advance_trans_op_itr', 'cuda_stream_query', "matmul", "matmul_2", "matmul_3", "transform",  "context_push_n_pop",
               "graphics_interop_d3d11", 'graph', 'asm_shfl', 'asm_shfl_sync', 'asm_shfl_sync_with_exp', 'asm_membar_fence',
-              'cub_block_store', 'asm_red', 'asm_cp', 'asm_prmt', 'asm_brkpt', 'asm_add', 'asm_sub', 'asm_cvt', 'asm_st']
+              'cub_block_store', 'asm_red', 'asm_cp', 'asm_prmt', 'asm_brkpt', 'asm_add', 'asm_sub', 'asm_cvt', 'asm_st', 'asm_ld']
 
 occupancy_calculation_exper = ['occupancy_calculation']
 


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>