### PR TITLE
[PTX] Added E2E case for ldmatrix PTX instruction

### DIFF
--- a/features/feature_case/asm/asm_ldmatrix.cu
+++ b/features/feature_case/asm/asm_ldmatrix.cu
@@ -22,6 +22,21 @@
     }                                                                          \
   }
 
+#define LAUNCH_TEST(TEST)                                                      \
+  if (!launch_test_##TEST) {                                                   \
+    return false;                                                              \
+  }
+
+
+template <int Shape_M, int Shape_N>
+void calculate_num_matrices(int M, int N, int &NUM_MATRICES) {
+  NUM_MATRICES = 0;
+
+  if (M % Shape_M == 0 && N % Shape_N == 0) {
+    NUM_MATRICES = (M * N) / (Shape_M * Shape_N);
+  }
+}
+
 __device__ void ldmatrix_x1(void *addr, volatile int *r) {
     unsigned int addr_int = __cvta_generic_to_shared(addr);
 
@@ -118,10 +133,10 @@ __global__ void ldmatrix_kernel(half *input, half *output, const int ELEMENTS_PE
   }
 }
 
-template <bool TRANS = false, int X = 1>
-bool run_test(const int ROWS, const int COLS, const int NUM_MATRICES) {
-  const int MATRIX_SIZE = ROWS * COLS;
-  const int TOTAL_ELEMENTS = NUM_MATRICES * MATRIX_SIZE;
+template <int Shape_M, int Shape_N, bool TRANS = false, int X = 1>
+bool run_test_ldmatrix_b16(const int ROWS, const int COLS, const int NUM_MATRICES) {
+  const int MATRIX_SIZE = Shape_M * Shape_N;
+  const int TOTAL_ELEMENTS = ROWS * COLS;
 
   // Allocate host memory for matrices
   half *h_input = new half[TOTAL_ELEMENTS];
@@ -145,9 +160,9 @@ bool run_test(const int ROWS, const int COLS, const int NUM_MATRICES) {
     int val = 0;
 
     for (int k = 0; k < NUM_MATRICES; k++) {
-      for (int c = 0; c < COLS; c++) {
-        for (int r = 0; r < ROWS; r++) {
-          exp_output[k * MATRIX_SIZE + r * COLS + c] = static_cast<half>(val++);
+      for (int c = 0; c < Shape_N; c++) {
+        for (int r = 0; r < Shape_M; r++) {
+          exp_output[k * MATRIX_SIZE + r * Shape_N + c] = static_cast<half>(val++);
         }
       }
     }
@@ -155,9 +170,9 @@ bool run_test(const int ROWS, const int COLS, const int NUM_MATRICES) {
     int val = 0;
 
     for (int k = 0; k < NUM_MATRICES; k++) {
-      for (int r = 0; r < ROWS; r++) {
-        for (int c = 0; c < COLS; c++) {
-          exp_output[k * MATRIX_SIZE + r * COLS + c] = static_cast<half>(val++);
+      for (int r = 0; r < Shape_M; r++) {
+        for (int c = 0; c < Shape_N; c++) {
+          exp_output[k * MATRIX_SIZE + r * Shape_N + c] = static_cast<half>(val++);
         }
       }
     }
@@ -166,7 +181,7 @@ bool run_test(const int ROWS, const int COLS, const int NUM_MATRICES) {
   // Copy input matrix to device
   cudaMemcpy(d_input, h_input, TOTAL_ELEMENTS * sizeof(half), cudaMemcpyHostToDevice);
 
-  int no_mat_block = NO_HALVES_PER_BLOCK / (8 * 8);
+  int no_mat_block = NO_HALVES_PER_BLOCK / (Shape_M * Shape_N);
   int no_blocks = NUM_MATRICES / no_mat_block;
   int no_threads;
   if (no_blocks) {
@@ -187,16 +202,16 @@ bool run_test(const int ROWS, const int COLS, const int NUM_MATRICES) {
 
   // Compare input & expected matrices data
   bool pass = true;
-  for (int k = 0; k < NUM_MATRICES; k++) {
-    for (int r = 0; r < ROWS; r++) {
-      for (int c = 0; c < COLS; c++) {
-        int index = k * MATRIX_SIZE + r * COLS + c;
+  for (int r = 0; r < ROWS; r++) {
+    for (int c = 0; c < COLS; c++) {
+      int index = r * COLS + c;
 
-        float out = __half2float(h_output[index]);
-        float exp_out = __half2float(exp_output[index]);
+      float out = __half2float(h_output[index]);
+      float exp_out = __half2float(exp_output[index]);
 
-        if (out != exp_out)
-          pass = false;
+      if (out != exp_out) {
+        std::cout << "Mismatch at index " << index << ": expected " << exp_out << ", got " << out << std::endl;
+        pass = false;
       }
     }
   }
@@ -210,68 +225,115 @@ bool run_test(const int ROWS, const int COLS, const int NUM_MATRICES) {
   return pass;
 }
 
-bool ldmatrix_m8n8_b16_x1() {
-  // Matrix dimensions
-  const int ROWS = 8;
-  const int COLS = 8;
-  const int NUM_MATRICES = 1;
+bool launch_test_ldmatrix_m8n8_b16_x1(const int M, const int N) {
+  int NUM_MATRICES;
+  calculate_num_matrices<8, 8>(M, N, NUM_MATRICES);
 
-  return run_test<false, 1>(ROWS, COLS, NUM_MATRICES);
+  if (NUM_MATRICES == 0) {
+    std::cerr << "Matrix dimensions are not compatible with m8n8.x1 (b16): " << M << ", " << N << std::endl;
+    return false;
+  }
+
+  bool correct;
+  correct = run_test_ldmatrix_b16<8, 8, false, 1>(M, N, NUM_MATRICES);
+  if (!correct) {
+    std::cerr << "m8n8.x1 (b16) failed for dims: " << M << ", " << N << std::endl;
+    return false;
+  }
+
+  correct = run_test_ldmatrix_b16<8, 8, true, 1>(M, N, NUM_MATRICES);
+  if (!correct) {
+    std::cerr << "m8n8.x1.trans (b16) failed for dims: " << M << ", " << N << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+bool launch_test_ldmatrix_m8n8_b16_x2(const int M, const int N) {
+  int NUM_MATRICES;
+  calculate_num_matrices<8, 8>(M, N, NUM_MATRICES);
+
+  if (NUM_MATRICES == 0) {
+    std::cerr << "Matrix dimensions are not compatible with m8n8.x2 (b16): " << M << ", " << N << std::endl;
+    return false;
+  }
+
+  bool correct;
+  correct = run_test_ldmatrix_b16<8, 8, false, 2>(M, N, NUM_MATRICES);
+  if (!correct) {
+    std::cerr << "m8n8.x2 (b16) failed for dims: " << M << ", " << N << std::endl;
+    return false;
+  }
+
+  correct = run_test_ldmatrix_b16<8, 8, true, 2>(M, N, NUM_MATRICES);
+  if (!correct) {
+    std::cerr << "m8n8.x2.trans (b16) failed for dims: " << M << ", " << N << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+bool launch_test_ldmatrix_m8n8_b16_x4(const int M, const int N) {
+  int NUM_MATRICES;
+  calculate_num_matrices<8, 8>(M, N, NUM_MATRICES);
+
+  if (NUM_MATRICES == 0) {
+    std::cerr << "Matrix dimensions are not compatible with m8n8.x4 (b16): " << M << ", " << N << std::endl;
+    return false;
+  }
+
+  bool correct;
+  correct = run_test_ldmatrix_b16<8, 8, false, 4>(M, N, NUM_MATRICES);
+  if (!correct) {
+    std::cerr << "m8n8.x4 (b16) failed for dims: " << M << ", " << N << std::endl;
+    return false;
+  }
+
+  correct = run_test_ldmatrix_b16<8, 8, true, 4>(M, N, NUM_MATRICES);
+  if (!correct) {
+    std::cerr << "m8n8.x4.trans (b16) failed for dims: " << M << ", " << N << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+bool ldmatrix_m8n8_b16_x1() {
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x1(8, 8));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x1(16, 16));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x1(8, 16));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x1(16, 8));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x1(32, 32));
+
+  return true;
 }
 
 bool ldmatrix_m8n8_b16_x2() {
-  // Matrix dimensions
-  const int ROWS = 8;
-  const int COLS = 8;
-  const int NUM_MATRICES = 2;
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x2(8, 16));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x2(16, 32));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x2(8, 32));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x2(16, 8));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x2(32, 32));
 
-  return run_test<false, 2>(ROWS, COLS, NUM_MATRICES);
+  return true;
 }
 
 bool ldmatrix_m8n8_b16_x4() {
-  // Matrix dimensions
-  const int ROWS = 8;
-  const int COLS = 8;
-  const int NUM_MATRICES = 4;
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x4(8, 32));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x4(16, 64));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x4(8, 64));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x4(16, 32));
+  LAUNCH_TEST(ldmatrix_m8n8_b16_x4(32, 32));
 
-  return run_test<false, 4>(ROWS, COLS, NUM_MATRICES);
-}
-
-bool ldmatrix_m8n8_b16_x1_trans() {
-  // Matrix dimensions
-  const int ROWS = 8;
-  const int COLS = 8;
-  const int NUM_MATRICES = 1;
-
-  return run_test<true, 1>(ROWS, COLS, NUM_MATRICES);
-}
-
-bool ldmatrix_m8n8_b16_x2_trans() {
-  // Matrix dimensions
-  const int ROWS = 8;
-  const int COLS = 8;
-  const int NUM_MATRICES = 2;
-
-  return run_test<true, 2>(ROWS, COLS, NUM_MATRICES);
-}
-
-bool ldmatrix_m8n8_b16_x4_trans() {
-  // Matrix dimensions
-  const int ROWS = 8;
-  const int COLS = 8;
-  const int NUM_MATRICES = 4;
-
-  return run_test<true, 4>(ROWS, COLS, NUM_MATRICES);
+  return true;
 }
 
 int main() {
   TEST(ldmatrix_m8n8_b16_x1);
   TEST(ldmatrix_m8n8_b16_x2);
   TEST(ldmatrix_m8n8_b16_x4);
-
-  TEST(ldmatrix_m8n8_b16_x1_trans);
-  TEST(ldmatrix_m8n8_b16_x2_trans);
-  TEST(ldmatrix_m8n8_b16_x4_trans);
 
   return 0;
 }

--- a/features/feature_case/asm/asm_ldmatrix.cu
+++ b/features/feature_case/asm/asm_ldmatrix.cu
@@ -1,0 +1,277 @@
+// ====------------- asm_ldmatrix.cu ------------- *- CUDA -* -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===---------------------------------------------------------------------===//
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <iostream>
+
+#define NO_HALVES_PER_BLOCK 1024
+
+#define TEST(FN)                                                               \
+  {                                                                            \
+    if (FN()) {                                                                \
+      printf("Test " #FN " PASS\n");                                           \
+    } else {                                                                   \
+      printf("Test " #FN " FAIL\n");                                           \
+      return 1;                                                                \
+    }                                                                          \
+  }
+
+__device__ void ldmatrix_x1(void *addr, int *r) {
+    unsigned int addr_int = __cvta_generic_to_shared(addr);
+
+    asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
+                : "=r"(r[0])
+                : "r"(addr_int));
+}
+
+__device__ void ldmatrix_x2(void *addr, int *r) {
+    unsigned int addr_int = __cvta_generic_to_shared(addr);
+
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+                  : "=r"(r[0]), "=r"(r[1])
+                  : "r"(addr_int));
+}
+
+__device__ void ldmatrix_x4(void *addr, int *r) {
+    unsigned int addr_int = __cvta_generic_to_shared(addr);
+
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                  : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3])
+                  : "r"(addr_int));
+}
+
+__device__ void ldmatrix_x1_trans(void *addr, int *r) {
+    unsigned int addr_int = __cvta_generic_to_shared(addr);
+
+    asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
+                  : "=r"(r[0])
+                  : "r"(addr_int));
+}
+
+__device__ void ldmatrix_x2_trans(void *addr, int *r) {
+    unsigned int addr_int = __cvta_generic_to_shared(addr);
+
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+                  : "=r"(r[0]), "=r"(r[1])
+                  : "r"(addr_int));
+}
+
+__device__ void ldmatrix_x4_trans(void *addr, int *r) {
+    unsigned int addr_int = __cvta_generic_to_shared(addr);
+
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                  : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3])
+                  : "r"(addr_int));
+}
+
+template <bool TRANS = false, int X = 1>
+__global__ void ldmatrix_kernel(half *input, half *output, const int ELEMENTS_PER_BLOCK) {
+  const int MATRIX_SIZE = 8 * 8;
+
+  __shared__ half shared_data[NO_HALVES_PER_BLOCK];
+
+  int lane_id = threadIdx.x % 32;
+  int warp_id = threadIdx.x / 32;
+
+  for (int i = threadIdx.x; i < ELEMENTS_PER_BLOCK; i += blockDim.x) {
+    shared_data[i] = input[blockIdx.x * ELEMENTS_PER_BLOCK + i];
+  }
+
+  __syncthreads();
+
+  int row_offset = MATRIX_SIZE * X * warp_id;
+  if (lane_id < X * 8)
+    row_offset += (8 * lane_id);
+
+  void *addr = shared_data + row_offset;
+  int r[X];
+
+  if (TRANS) {
+    if (X == 1)
+      ldmatrix_x1_trans(addr, r);
+    else if (X == 2)
+      ldmatrix_x2_trans(addr, r);
+    else if (X == 4)
+      ldmatrix_x4_trans(addr, r);
+  } else {
+    if (X == 1)
+      ldmatrix_x1(addr, r);
+    else if (X == 2)
+      ldmatrix_x2(addr, r);
+    else if (X == 4)
+      ldmatrix_x4(addr, r);
+  }
+
+  for (int i = 0; i < X; i++) {
+    int d_ind = i * MATRIX_SIZE + 2 * lane_id;
+
+    if (d_ind + 1 < ELEMENTS_PER_BLOCK) {
+      output[blockIdx.x * ELEMENTS_PER_BLOCK + MATRIX_SIZE * X * warp_id + d_ind]     = ((half *)(&r[i]))[0];
+      output[blockIdx.x * ELEMENTS_PER_BLOCK + MATRIX_SIZE * X * warp_id + d_ind + 1] = ((half *)(&r[i]))[1];
+    }
+  }
+}
+
+template <bool TRANS = false, int X = 1>
+bool run_test(const int ROWS, const int COLS, const int NUM_MATRICES) {
+  const int MATRIX_SIZE = ROWS * COLS;
+  const int TOTAL_ELEMENTS = NUM_MATRICES * MATRIX_SIZE;
+
+  // Allocate host memory for matrices
+  half *h_input = new half[TOTAL_ELEMENTS];
+  half *h_output = new half[TOTAL_ELEMENTS];
+  half *exp_output = new half[TOTAL_ELEMENTS];
+
+  // Allocate device memory for matrices
+  half *d_input;
+  half *d_output;
+  cudaMalloc(&d_input, TOTAL_ELEMENTS * sizeof(half));
+  cudaMalloc(&d_output, TOTAL_ELEMENTS * sizeof(half));
+  cudaMemset(d_output, 0, TOTAL_ELEMENTS * sizeof(half));
+
+  // Initialize input matrix with some values
+  for (int i = 0; i < TOTAL_ELEMENTS; i++) {
+      h_input[i] = static_cast<half>(i);
+  }
+
+  // Initialize expected matrix with some values
+  if (TRANS) {
+    int val = 0;
+
+    for (int k = 0; k < NUM_MATRICES; k++) {
+      for (int c = 0; c < COLS; c++) {
+        for (int r = 0; r < ROWS; r++) {
+          exp_output[k * MATRIX_SIZE + r * COLS + c] = static_cast<half>(val++);
+        }
+      }
+    }
+  } else {
+    int val = 0;
+
+    for (int k = 0; k < NUM_MATRICES; k++) {
+      for (int r = 0; r < ROWS; r++) {
+        for (int c = 0; c < COLS; c++) {
+          exp_output[k * MATRIX_SIZE + r * COLS + c] = static_cast<half>(val++);
+        }
+      }
+    }
+  }
+
+  // Copy input matrix to device
+  cudaMemcpy(d_input, h_input, TOTAL_ELEMENTS * sizeof(half), cudaMemcpyHostToDevice);
+
+  int no_mat_block = NO_HALVES_PER_BLOCK / (8 * 8);
+  int no_blocks = NUM_MATRICES / no_mat_block;
+  int no_threads;
+  if (no_blocks) {
+    no_threads = 32 * (no_mat_block / X);
+  } else {
+    no_blocks = 1;
+    no_threads = 32 * (NUM_MATRICES / X);
+  }
+  const int ELEMENTS_PER_BLOCK = no_threads * X * 2;
+
+  // Launch kernel
+  ldmatrix_kernel<TRANS, X><<<no_blocks, no_threads>>>(d_input, d_output, ELEMENTS_PER_BLOCK);
+
+  cudaDeviceSynchronize();
+
+  // Copy output matrix back to host
+  cudaMemcpy(h_output, d_output, TOTAL_ELEMENTS * sizeof(half), cudaMemcpyDeviceToHost);
+
+  // Compare input & expected matrices data
+  bool pass = true;
+  for (int k = 0; k < NUM_MATRICES; k++) {
+    for (int r = 0; r < ROWS; r++) {
+      for (int c = 0; c < COLS; c++) {
+        int index = k * MATRIX_SIZE + r * COLS + c;
+
+        float out = __half2float(h_output[index]);
+        float exp_out = __half2float(exp_output[index]);
+
+        if (out != exp_out)
+          pass = false;
+      }
+    }
+  }
+
+  // Cleanup
+  delete[] h_input;
+  delete[] h_output;
+  cudaFree(d_input);
+  cudaFree(d_output);
+
+  return pass;
+}
+
+bool ldmatrix_m8n8_b16_x1() {
+  // Matrix dimensions
+  const int ROWS = 8;
+  const int COLS = 8;
+  const int NUM_MATRICES = 1;
+
+  return run_test<false, 1>(ROWS, COLS, NUM_MATRICES);
+}
+
+bool ldmatrix_m8n8_b16_x2() {
+  // Matrix dimensions
+  const int ROWS = 8;
+  const int COLS = 8;
+  const int NUM_MATRICES = 2;
+
+  return run_test<false, 2>(ROWS, COLS, NUM_MATRICES);
+}
+
+bool ldmatrix_m8n8_b16_x4() {
+  // Matrix dimensions
+  const int ROWS = 8;
+  const int COLS = 8;
+  const int NUM_MATRICES = 4;
+
+  return run_test<false, 4>(ROWS, COLS, NUM_MATRICES);
+}
+
+bool ldmatrix_m8n8_b16_x1_trans() {
+  // Matrix dimensions
+  const int ROWS = 8;
+  const int COLS = 8;
+  const int NUM_MATRICES = 1;
+
+  return run_test<true, 1>(ROWS, COLS, NUM_MATRICES);
+}
+
+bool ldmatrix_m8n8_b16_x2_trans() {
+  // Matrix dimensions
+  const int ROWS = 8;
+  const int COLS = 8;
+  const int NUM_MATRICES = 2;
+
+  return run_test<true, 2>(ROWS, COLS, NUM_MATRICES);
+}
+
+bool ldmatrix_m8n8_b16_x4_trans() {
+  // Matrix dimensions
+  const int ROWS = 8;
+  const int COLS = 8;
+  const int NUM_MATRICES = 4;
+
+  return run_test<true, 4>(ROWS, COLS, NUM_MATRICES);
+}
+
+int main() {
+  TEST(ldmatrix_m8n8_b16_x1);
+  TEST(ldmatrix_m8n8_b16_x2);
+  TEST(ldmatrix_m8n8_b16_x4);
+
+  TEST(ldmatrix_m8n8_b16_x1_trans);
+  TEST(ldmatrix_m8n8_b16_x2_trans);
+  TEST(ldmatrix_m8n8_b16_x4_trans);
+
+  return 0;
+}

--- a/features/feature_case/asm/asm_ldmatrix.cu
+++ b/features/feature_case/asm/asm_ldmatrix.cu
@@ -22,7 +22,7 @@
     }                                                                          \
   }
 
-__device__ void ldmatrix_x1(void *addr, int *r) {
+__device__ void ldmatrix_x1(void *addr, volatile int *r) {
     unsigned int addr_int = __cvta_generic_to_shared(addr);
 
     asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n"
@@ -30,7 +30,7 @@ __device__ void ldmatrix_x1(void *addr, int *r) {
                 : "r"(addr_int));
 }
 
-__device__ void ldmatrix_x2(void *addr, int *r) {
+__device__ void ldmatrix_x2(void *addr, volatile int *r) {
     unsigned int addr_int = __cvta_generic_to_shared(addr);
 
     asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
@@ -38,7 +38,7 @@ __device__ void ldmatrix_x2(void *addr, int *r) {
                   : "r"(addr_int));
 }
 
-__device__ void ldmatrix_x4(void *addr, int *r) {
+__device__ void ldmatrix_x4(void *addr, volatile int *r) {
     unsigned int addr_int = __cvta_generic_to_shared(addr);
 
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
@@ -46,7 +46,7 @@ __device__ void ldmatrix_x4(void *addr, int *r) {
                   : "r"(addr_int));
 }
 
-__device__ void ldmatrix_x1_trans(void *addr, int *r) {
+__device__ void ldmatrix_x1_trans(void *addr, volatile int *r) {
     unsigned int addr_int = __cvta_generic_to_shared(addr);
 
     asm volatile("ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16 {%0}, [%1];\n"
@@ -54,7 +54,7 @@ __device__ void ldmatrix_x1_trans(void *addr, int *r) {
                   : "r"(addr_int));
 }
 
-__device__ void ldmatrix_x2_trans(void *addr, int *r) {
+__device__ void ldmatrix_x2_trans(void *addr, volatile int *r) {
     unsigned int addr_int = __cvta_generic_to_shared(addr);
 
     asm volatile("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
@@ -62,7 +62,7 @@ __device__ void ldmatrix_x2_trans(void *addr, int *r) {
                   : "r"(addr_int));
 }
 
-__device__ void ldmatrix_x4_trans(void *addr, int *r) {
+__device__ void ldmatrix_x4_trans(void *addr, volatile int *r) {
     unsigned int addr_int = __cvta_generic_to_shared(addr);
 
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
@@ -90,7 +90,7 @@ __global__ void ldmatrix_kernel(half *input, half *output, const int ELEMENTS_PE
     row_offset += (8 * lane_id);
 
   void *addr = shared_data + row_offset;
-  int r[X];
+  volatile int r[X];
 
   if (TRANS) {
     if (X == 1)

--- a/features/features.xml
+++ b/features/features.xml
@@ -22,6 +22,7 @@
     <test testName="asm_cp" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_st" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_ld" configFile="config/TEMPLATE_asm.xml" />
+    <test testName="asm_ldmatrix" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_brkpt" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_sub" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_add" configFile="config/TEMPLATE_asm.xml" />

--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -63,7 +63,7 @@ exec_tests = ['asm', 'asm_bar', 'asm_mem', 'asm_atom', 'asm_arith', 'asm_vinst',
               'thrust_device_new_delete', 'thrust_temporary_buffer', 'thrust_malloc_free', 'codepin', 'thrust_unique_count',
               'thrust_advance_trans_op_itr', 'cuda_stream_query', "matmul", "matmul_2", "matmul_3", "transform",  "context_push_n_pop",
               "graphics_interop_d3d11", 'graph', 'asm_shfl', 'asm_shfl_sync', 'asm_shfl_sync_with_exp', 'asm_membar_fence',
-              'cub_block_store', 'asm_red', 'asm_cp', 'asm_prmt', 'asm_brkpt', 'asm_add', 'asm_sub', 'asm_cvt', 'asm_st', 'asm_ld',
+              'cub_block_store', 'asm_red', 'asm_cp', 'asm_prmt', 'asm_brkpt', 'asm_add', 'asm_sub', 'asm_cvt', 'asm_st', 'asm_ld', 'asm_ldmatrix',
               'asm_mul', 'asm_neg', 'asm_cvta', 'pointer_attributes_usmnone']
 
 occupancy_calculation_exper = ['occupancy_calculation']


### PR DESCRIPTION
This PR adds E2E for below ldmatrix PTX instructions - 
- ldmatrix.sync.aligned.m8n8.x1.{trans.}shared.b16
- ldmatrix.sync.aligned.m8n8.x2.{trans.}shared.b16
- ldmatrix.sync.aligned.m8n8.x4.{trans.}shared.b16