### PR TITLE
[Driver] E2E case for 4 Blender Driver APIs & 1 ASM instruction

### DIFF
--- a/features/feature_case/asm/asm_arith.cu
+++ b/features/feature_case/asm/asm_arith.cu
@@ -690,6 +690,7 @@ __device__ int cvt() {
   { asm("cvt.rn.f64.u64 %0, %1;" : "=d"(f64) : "l"(3ll)); if (!(f64 == 3.0)) { return 66; } };
 
   { asm("cvt.rn.bf16.f32 %0, %1;" : "=h"(bf16) : "f"(3.14f)); if (!(bf16 == 0x4049)) { return 67; } };
+  { asm("cvt.rn.f16.f32 %0, %1;" : "=h"(f16) : "f"(3.14f)); if (!(f16 == 0x4248)) { return 68; } };
 
   return 0;
 }

--- a/features/feature_case/driverDevice/driverDevice.cu
+++ b/features/feature_case/driverDevice/driverDevice.cu
@@ -60,9 +60,7 @@ int main(){
 #else
   cuDeviceGetP2PAttribute(&result1, CU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED, device, peerDevice);
 #endif
-#if (CUDA_VERSION == 9020)
-  cuDeviceGetP2PAttribute(&result1, CU_DEVICE_P2P_ATTRIBUTE_ARRAY_ACCESS_ACCESS_SUPPORTED, device, peerDevice);
-#else
+#if (CUDA_VERSION != 9020)
   cuDeviceGetP2PAttribute(&result1, CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED, device, peerDevice);
 #endif
 

--- a/features/feature_case/driverDevice/driverDevice.cu
+++ b/features/feature_case/driverDevice/driverDevice.cu
@@ -16,7 +16,7 @@
 int main(){
   int result1, result2;
   int *presult1 = &result1, *presult2 = &result2;
-  CUdevice device;
+  CUdevice device, peerDevice;
   CUdevice *pdevice = &device;
   cuDeviceGet(&device, 0);
   cuDeviceGet(&device, NUM);
@@ -49,6 +49,23 @@ int main(){
 
   cuDeviceGetAttribute(&result1, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, device);
   cuDeviceGetAttribute(&result1, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK, device);
+
+  CUdevice_P2PAttribute p2p_attr = CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED;
+  cuDeviceGetP2PAttribute(&result1, p2p_attr, device, peerDevice);
+
+  cuDeviceGetP2PAttribute(&result1, CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED, device, peerDevice);
+  cuDeviceGetP2PAttribute(&result1, CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED, device, peerDevice);
+#if (CUDA_VERSION <= 10000)
+  cuDeviceGetP2PAttribute(&result1, CU_DEVICE_P2P_ATTRIBUTE_ARRAY_ACCESS_ACCESS_SUPPORTED, device, peerDevice);
+#else
+  cuDeviceGetP2PAttribute(&result1, CU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED, device, peerDevice);
+#endif
+#if (CUDA_VERSION == 9020)
+  cuDeviceGetP2PAttribute(&result1, CU_DEVICE_P2P_ATTRIBUTE_ARRAY_ACCESS_ACCESS_SUPPORTED, device, peerDevice);
+#else
+  cuDeviceGetP2PAttribute(&result1, CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED, device, peerDevice);
+#endif
+
   CUcontext context;
   unsigned int flags = CU_CTX_MAP_HOST;
   flags += CU_CTX_SCHED_BLOCKING_SYNC;
@@ -57,6 +74,11 @@ int main(){
   if (cuCtxCreate(&context, flags, device) == CUDA_SUCCESS) {
     return 0;
   }
+
+  cuDevicePrimaryCtxSetFlags(device, flags);
+
+  int active;
+  cuDevicePrimaryCtxGetState(device, &flags, &active);
 
   cuCtxSetCacheConfig(CU_FUNC_CACHE_PREFER_SHARED);
 

--- a/features/feature_case/driverMem/driverMem.cu
+++ b/features/feature_case/driverMem/driverMem.cu
@@ -99,6 +99,8 @@ void test1(){
 
     cuMemcpy2D(&cpy);
 
+    cuMemcpy2DUnaligned(&cpy);
+
     cuMemcpy2DAsync(&cpy, stream);
 
     CUDA_MEMCPY3D cpy2;


### PR DESCRIPTION
This PR adds E2E case for below 4 driver APIs & 1 ASM instruction used in APIs
- cuDevicePrimaryCtxSetFlags
- cuDevicePrimaryCtxGetState
- cuDeviceGetP2PAttribute
- cuMemcpy2DUnaligned
- cvt.rn.f16.f32