### PR TITLE
[PTX] Excluded syclcompat for ldmatrix & mma

### DIFF
--- a/features/features.xml
+++ b/features/features.xml
@@ -22,8 +22,8 @@
     <test testName="asm_cp" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_st" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_ld" configFile="config/TEMPLATE_asm.xml" />
-    <test testName="asm_ldmatrix" configFile="config/TEMPLATE_asm.xml" />
-    <test testName="asm_mma" configFile="config/TEMPLATE_asm.xml" />
+    <test testName="asm_ldmatrix" configFile="config/TEMPLATE_asm_excluding_syclcompat.xml" />
+    <test testName="asm_mma" configFile="config/TEMPLATE_asm_excluding_syclcompat.xml" />
     <test testName="asm_brkpt" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_sub" configFile="config/TEMPLATE_asm.xml" />
     <test testName="asm_add" configFile="config/TEMPLATE_asm.xml" />


### PR DESCRIPTION
This PR excludes running ldmatrix && mma cases on syclcompat option