### PR TITLE
[SYCLomatic] Testing sycl device-copyable for passed_directly types

### DIFF
--- a/help_function/src/onedpl_test_device_ptr.cpp
+++ b/help_function/src/onedpl_test_device_ptr.cpp
@@ -116,6 +116,16 @@ int test_device_ptr_iteration(void)
 }
 
 int main() {
+
+#ifndef DPCT_USM_LEVEL_NONE
+    // If USM is used, then device_pointer must be device copyable to be passed directly into oneDPL
+    static_assert(sycl::is_device_copyable_v<dpct::device_pointer<int>>);
+    static_assert(sycl::is_device_copyable_v<dpct::device_pointer<void>>);
+
+    static_assert(sycl::is_device_copyable_v<dpct::device_iterator<int>>);
+    static_assert(sycl::is_device_copyable_v<dpct::device_iterator<void>>);
+#endif
+
     int failed_tests = test_device_ptr_manipulation();
     failed_tests += test_device_ptr_iteration();
 

--- a/help_function/src/onedpl_test_tagged_pointer.cpp
+++ b/help_function/src/onedpl_test_tagged_pointer.cpp
@@ -133,7 +133,13 @@ int test_tagged_pointer_iteration(Policy policy, std::string test_name) {
 }
 
 int main() {
-  int failed_tests = test_tagged_pointer_manipulation<dpct::host_sys_tag>();
+#ifndef DPCT_USM_LEVEL_NONE
+  // If USM is used, then tagged_pointer must be device copyable to be passed directly into oneDPL
+  static_assert(sycl::is_device_copyable_v<dpct::tagged_pointer<int, dpct::device_sys_tag>>);
+  static_assert(sycl::is_device_copyable_v<dpct::tagged_pointer<void, dpct::device_sys_tag>>);
+#endif
+
+int failed_tests = test_tagged_pointer_manipulation<dpct::host_sys_tag>();
   failed_tests += test_tagged_pointer_manipulation<dpct::device_sys_tag>();
 
   failed_tests += test_tagged_pointer_iteration(


### PR DESCRIPTION
Types intended to pass directly into sycl kernels need to be device-copyable.  
Adding tests to confirm this with static asserts.