### PR TITLE
[SYCLomatic] Skip set tests with no double support

### DIFF
--- a/help_function/help_function.xml
+++ b/help_function/help_function.xml
@@ -128,10 +128,10 @@
     <test testName="onedpl_test_replace_copy_if" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_sequence" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_segmented_sort_pairs" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
-    <test testName="onedpl_test_set_difference_by_key" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
-    <test testName="onedpl_test_set_intersection_by_key" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
-    <test testName="onedpl_test_set_symmetric_difference_by_key" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
-    <test testName="onedpl_test_set_union_by_key" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
+    <test testName="onedpl_test_set_difference_by_key" configFile="config/TEMPLATE_help_function_skip_double.xml" splitGroup="double"/>
+    <test testName="onedpl_test_set_intersection_by_key" configFile="config/TEMPLATE_help_function_skip_double.xml" splitGroup="double"/>
+    <test testName="onedpl_test_set_symmetric_difference_by_key" configFile="config/TEMPLATE_help_function_skip_double.xml" splitGroup="double"/>
+    <test testName="onedpl_test_set_union_by_key" configFile="config/TEMPLATE_help_function_skip_double.xml" splitGroup="double"/>
     <test testName="onedpl_test_sort_by_key" configFile="config/TEMPLATE_help_function_skip_cuda_backend.xml" />
     <test testName="onedpl_test_sort_keys" configFile="config/TEMPLATE_help_function_skip_double.xml" />
     <test testName="onedpl_test_sort_pairs" configFile="config/TEMPLATE_help_function_skip_double.xml" />


### PR DESCRIPTION
This PR should skip the set tests when double support is not present.

Please check this work, I'm not certain about the `splitGroup="double"` part here, as it is not consistent throughout this file.

Also, if there were a way to do this only for Windows that would be sufficient, but I don't know how to do that.

This PR can be reverted once depending on a oneDPL version after https://github.com/uxlfoundation/oneDPL/pull/2251.