### PR TITLE
[NFC][Bug] Skipping test from running on Win as its not supported by nvSHMEM

### DIFF
--- a/features/config/TEMPLATE_nvSHMEM.xml
+++ b/features/config/TEMPLATE_nvSHMEM.xml
@@ -7,7 +7,7 @@
     </files>
     <rules>
         <platformRule OSFamily="Linux" kit="CUDA10.1" kitRange="OLDER" runOnThisPlatform="false"/>
-        <platformRule OSFamily="Windows" kit="CUDA10.1" kitRange="OLDER" runOnThisPlatform="false"/>
+        <platformRule OSFamily="Windows" runOnThisPlatform="false"/>
         <optlevelRule excludeOptlevelNameString="cpu"/>
         <optlevelRule excludeOptlevelNameString="cuda"/>
         <optlevelRule excludeOptlevelNameString="syclcompat"/>


### PR DESCRIPTION
This PR excludes running nvshmem test on Windows, as its not supported by nvSHMEM library