### PR TITLE
Update more tests

### DIFF
--- a/features/features.xml
+++ b/features/features.xml
@@ -365,7 +365,7 @@
     <test testName="text_experimental_obj_sample_api" configFile="config/TEMPLATE_image_excluding_syclcompat.xml" />
     <test testName="text_experimental_obj_surf" configFile="config/TEMPLATE_image_excluding_syclcompat.xml" />
     <test testName="text_obj_array" configFile="config/TEMPLATE_image_skip_cuda_excluding_syclcompat.xml" />
-    <test testName="text_obj_linear" configFile="config/TEMPLATE_image_skip_cuda.xml" />
+    <test testName="text_obj_linear" configFile="config/TEMPLATE_image_skip_cuda_excluding_syclcompat.xml" />
     <test testName="text_obj_pitch2d" configFile="config/TEMPLATE_image_skip_cuda_excluding_syclcompat.xml" />
     <test testName="defaultStream" configFile="config/TEMPLATE_defaultStream.xml" />
     <test testName="volatile-vec" configFile="config/TEMPLATE_misc.xml" />

--- a/features/test_feature.py
+++ b/features/test_feature.py
@@ -26,7 +26,7 @@ cmpllink_only_as_wa_tests = ['thrust-op', 'curand', 'curand-usm', 'curand-cross-
                          'cufft-different-locations-usm', 'cufft-reuse-handle', 'cufft-different-locations', 'cufft-usm', 'cufft', 'cooperative_groups', 'driverCtx', 'driverDevice', 'driverArray', 'driverTex',
                          'driverMemset', 'cub_warp', 'cub_device_run_length_encode_encode', 'cooperative_group_coalesced_group', 'text_experimental_build_only',
                          'wmma', 'assert', 'peer_access_using_driver_api', 'curand-device-usm', 'curand-device', 'cufft-func-ptr', 'cufft-others', 'cub_block', 'codepin_basic', 'math-direct', 'math-helper', 'grid_sync_root_group', 'device_cpu', 'image',
-                        'nvshmem']
+                        'nvshmem', 'cudnn-rnn']
 
 occupancy_calculation_exper = ['occupancy_calculation']
 


### PR DESCRIPTION
text_obj_linear test is not ready for SYCLCompat. Update config for it to skip syclcompat.
cudnn-rnn is to compile and link only.