### PR TITLE
[SYCLomatic] Update test case thrust_partition.cu to fix dpct parse error "no member named 'find_if_not' in namespace 'thrust'" on Windows

### DIFF
--- a/features/feature_case/thrust/thrust_partition.cu
+++ b/features/feature_case/thrust/thrust_partition.cu
@@ -11,6 +11,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
 #include <thrust/extrema.h>
+#include <thrust/find.h>
 #include <thrust/host_vector.h>
 #include <thrust/partition.h>
 #include <thrust/sort.h>


### PR DESCRIPTION
 Signed-off-by: chenwei.sun <chenwei.sun@intel.com>